### PR TITLE
Fix synthesis timeout and add Rich markdown rendering

### DIFF
--- a/qadi_simple_multi.py
+++ b/qadi_simple_multi.py
@@ -13,6 +13,24 @@ from pathlib import Path
 import time
 from mad_spark_alt.core.terminal_renderer import render_phase_indicator, render_section_header, render_summary_section
 
+
+def display_phase_results(title: str, emoji: str, content: str, prefix: str) -> None:
+    """Display phase content with prefix-based or fallback formatting."""
+    print(f"\n{emoji} {title}:")
+    
+    # Check if there are lines with the expected prefix
+    prefixed_lines = [line for line in content.split('\n') if line.strip() and line.startswith(f'{prefix}:')]
+    
+    if prefixed_lines:
+        # Use prefixed lines and strip the prefix
+        for line in prefixed_lines:
+            print(f"  • {line[2:].strip()}")
+    else:
+        # Fallback to all non-empty lines if no prefix found
+        for line in content.split('\n'):
+            if line.strip():
+                print(f"  • {line.strip()}")
+
 # Load .env
 env_path = Path(__file__).parent / '.env'
 if env_path.exists():
@@ -236,53 +254,10 @@ async def run_simple_multi_agent_qadi(prompt: str, concrete_mode: bool = False, 
     # Display results
     render_section_header("MULTI-AGENT QADI ANALYSIS", "🔍")
     
-    print("\n❓ QUESTIONING:")
-    # Check if there are lines with Q: prefix, otherwise show all non-empty lines
-    q_lines = [line for line in questions.split('\n') if line.strip() and line.startswith('Q:')]
-    if q_lines:
-        for line in q_lines:
-            print(f"  • {line[2:].strip()}")
-    else:
-        # Show all non-empty lines if no Q: prefix found
-        for line in questions.split('\n'):
-            if line.strip():
-                print(f"  • {line.strip()}")
-    
-    print("\n💡 ABDUCTION:")
-    # Check if there are lines with H: prefix, otherwise show all non-empty lines
-    h_lines = [line for line in hypotheses.split('\n') if line.strip() and line.startswith('H:')]
-    if h_lines:
-        for line in h_lines:
-            print(f"  • {line[2:].strip()}")
-    else:
-        # Show all non-empty lines if no H: prefix found
-        for line in hypotheses.split('\n'):
-            if line.strip():
-                print(f"  • {line.strip()}")
-    
-    print("\n🔍 DEDUCTION:")
-    # Check if there are lines with D: prefix, otherwise show all non-empty lines
-    d_lines = [line for line in deductions.split('\n') if line.strip() and line.startswith('D:')]
-    if d_lines:
-        for line in d_lines:
-            print(f"  • {line[2:].strip()}")
-    else:
-        # Show all non-empty lines if no D: prefix found
-        for line in deductions.split('\n'):
-            if line.strip():
-                print(f"  • {line.strip()}")
-    
-    print("\n🎯 INDUCTION:")
-    # Check if there are lines with I: prefix, otherwise show all non-empty lines
-    i_lines = [line for line in patterns.split('\n') if line.strip() and line.startswith('I:')]
-    if i_lines:
-        for line in i_lines:
-            print(f"  • {line[2:].strip()}")
-    else:
-        # Show all non-empty lines if no I: prefix found
-        for line in patterns.split('\n'):
-            if line.strip():
-                print(f"  • {line.strip()}")
+    display_phase_results("QUESTIONING", "❓", questions, "Q")
+    display_phase_results("ABDUCTION", "💡", hypotheses, "H")
+    display_phase_results("DEDUCTION", "🔍", deductions, "D")
+    display_phase_results("INDUCTION", "🎯", patterns, "I")
     
     # Final synthesis
     render_section_header("SYNTHESIS", "✨")

--- a/src/mad_spark_alt/core/terminal_renderer.py
+++ b/src/mad_spark_alt/core/terminal_renderer.py
@@ -53,7 +53,6 @@ class TerminalRenderer:
         content: str,
         title: str = "",
         border_style: str = "blue",
-        title_style: str = "bold",
     ) -> None:
         """
         Render content in a styled panel.
@@ -62,7 +61,6 @@ class TerminalRenderer:
             content: Content to display in panel
             title: Panel title
             border_style: Border color/style
-            title_style: Title text style
         """
         if self._fallback_mode:
             # Simple fallback without panels
@@ -73,7 +71,7 @@ class TerminalRenderer:
         else:
             try:
                 panel = Panel(
-                    content, title=title, border_style=border_style, title_align="left", title_style=title_style
+                    content, title=title, border_style=border_style, title_align="left"
                 )
                 self.console.print(panel)
             except Exception:


### PR DESCRIPTION
## Summary
- Fixed synthesis timeout issues that were cutting off responses
- Added Rich-based markdown rendering for beautiful CLI output
- Fixed missing ABDUCTION and INDUCTION content display
- Improved prompt formatting for consistent QADI phase outputs

## Changes Made

### 1. Timeout Fixes
- Increased synthesis timeout from 20s to 60s
- Increased max_tokens from 400 to 800, then to 1500 for Japanese responses
- Added proper exception handling to show actual error messages

### 2. Context Window Management
- Added text truncation to avoid Google API context window limits
- Implemented smart key insights extraction to preserve essential content
- Added "Respond in same language" instruction for consistent language output

### 3. Rich Markdown Rendering
- Created `terminal_renderer.py` utility module with Rich integration
- Synthesis output now renders **bold**, *italic*, numbered lists properly
- Enhanced section headers with styled formatting and emojis
- Added graceful fallback for terminals without color support

### 4. Display Improvements
- Fixed empty ABDUCTION and INDUCTION sections
- Added fallback logic for when LLM doesn't use expected prefixes
- Improved prompts to ensure consistent Q:, H:, D:, I: formatting
- Enhanced phase indicators and summary sections with Rich styling

## Test Results
- ✅ Synthesis completes without timeout
- ✅ Japanese responses work properly and stay in Japanese
- ✅ All QADI phases display content correctly
- ✅ Markdown renders beautifully in terminal
- ✅ Works across different question types and languages

## Before/After

**Before:**
- Synthesis: `(Synthesis timed out)`
- Raw markdown: `**[Action-focused title]:** [Details]`
- Missing ABDUCTION/INDUCTION content

**After:**
- Complete synthesis with actionable recommendations
- Properly rendered markdown with formatting
- All QADI phases display complete content
- Professional terminal output with Rich styling