### PR TITLE
feat: add multi-perspective QADI analysis system

### DIFF
--- a/qadi_multi_perspective.py
+++ b/qadi_multi_perspective.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""
+Multi-Perspective QADI Analysis
+
+This script provides QADI analysis from multiple perspectives based on
+automatic intent detection, ensuring answers match the user's actual needs.
+
+Usage:
+    uv run python qadi_multi_perspective.py "Your question here"
+    uv run python qadi_multi_perspective.py "Your question" --perspectives environmental,personal
+    uv run python qadi_multi_perspective.py "Your question" --temperature 0.9
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+import time
+from pathlib import Path
+from typing import List, Optional
+
+try:
+    from mad_spark_alt.core import setup_llm_providers
+    from mad_spark_alt.core.intent_detector import IntentDetector, QuestionIntent
+    from mad_spark_alt.core.multi_perspective_orchestrator import (
+        MultiPerspectiveQADIOrchestrator,
+        PerspectiveResult,
+    )
+    from mad_spark_alt.core.terminal_renderer import render_markdown
+except ImportError:
+    # Fallback if package is not installed
+    sys.path.insert(0, str(Path(__file__).parent / "src"))
+    from mad_spark_alt.core import setup_llm_providers
+    from mad_spark_alt.core.intent_detector import IntentDetector, QuestionIntent
+    from mad_spark_alt.core.multi_perspective_orchestrator import (
+        MultiPerspectiveQADIOrchestrator,
+        PerspectiveResult,
+    )
+    from mad_spark_alt.core.terminal_renderer import render_markdown
+
+
+def display_intent_detection(intent_result, perspectives: List[QuestionIntent]) -> None:
+    """Display intent detection results."""
+    print("\n🔍 Intent Detection:")
+    print(f"Primary Intent: {intent_result.primary_intent.value.title()} "
+          f"(confidence: {intent_result.confidence:.0%})")
+    
+    if intent_result.keywords_matched:
+        print(f"Keywords Detected: {', '.join(intent_result.keywords_matched[:5])}")
+    
+    print(f"\n📊 Analysis Perspectives: {', '.join(p.value.title() for p in perspectives)}")
+    print("─" * 70)
+
+
+def display_perspective_result(pr: PerspectiveResult, is_primary: bool = False) -> None:
+    """Display results from a single perspective."""
+    emoji_map = {
+        QuestionIntent.ENVIRONMENTAL: "🌍",
+        QuestionIntent.PERSONAL: "👤",
+        QuestionIntent.TECHNICAL: "💻",
+        QuestionIntent.BUSINESS: "💼",
+        QuestionIntent.SCIENTIFIC: "🔬",
+        QuestionIntent.PHILOSOPHICAL: "🤔",
+        QuestionIntent.GENERAL: "📋",
+    }
+    
+    emoji = emoji_map.get(pr.perspective, "📋")
+    header = f"{emoji} {pr.perspective.value.title()} Perspective"
+    if is_primary:
+        header += " (Primary)"
+    
+    print(f"\n{'=' * 70}")
+    print(f"{header}")
+    print(f"{'=' * 70}")
+    
+    # Core Question
+    print(f"\n**Core Question:**")
+    render_markdown(pr.result.core_question)
+    
+    # Hypotheses with scores
+    print(f"\n**Hypotheses:**")
+    for i, (hyp, score) in enumerate(zip(pr.result.hypotheses, pr.result.hypothesis_scores)):
+        score_bar = "█" * int(score.overall * 10) + "░" * (10 - int(score.overall * 10))
+        print(f"\nH{i+1} [{score_bar}] {score.overall:.2f}")
+        render_markdown(hyp)
+    
+    # Answer
+    print(f"\n**Answer:**")
+    render_markdown(pr.result.final_answer)
+    
+    # Action Plan - Fixed formatting
+    if pr.result.action_plan:
+        print(f"\n**Action Plan:**")
+        for i, action in enumerate(pr.result.action_plan, 1):
+            # Clean action text and ensure proper formatting
+            action_text = action.strip()
+            print(f"{i}. {action_text}")
+    
+    # Verification Examples (shortened for multi-perspective view)
+    if pr.result.verification_examples:
+        print(f"\n**Key Verification:**")
+        # Show only first example in multi-perspective mode
+        render_markdown(f"• {pr.result.verification_examples[0][:200]}...")
+
+
+def display_synthesis(result) -> None:
+    """Display synthesized results."""
+    print(f"\n{'=' * 70}")
+    print("🎯 Synthesized Analysis")
+    print(f"{'=' * 70}")
+    
+    print("\n**Integrated Answer:**")
+    render_markdown(result.synthesized_answer)
+    
+    print(f"\n**Best Hypothesis:** ({result.best_hypothesis[1].value.title()} perspective)")
+    render_markdown(result.best_hypothesis[0])
+    
+    print("\n**Integrated Action Plan:**")
+    for i, action in enumerate(result.synthesized_action_plan, 1):
+        action_text = action.strip()
+        print(f"{i}. {action_text}")
+
+
+async def run_multi_perspective_analysis(
+    user_input: str,
+    temperature: Optional[float] = None,
+    force_perspectives: Optional[List[str]] = None,
+    show_all_perspectives: bool = False,
+) -> None:
+    """Run multi-perspective QADI analysis."""
+    
+    print("🧠 Multi-Perspective QADI Analysis")
+    print("=" * 70)
+    print(f"\n📝 User Input: {user_input}")
+    
+    # Check for API key
+    google_key = os.getenv("GOOGLE_API_KEY")
+    if not google_key:
+        print("\n❌ Error: GOOGLE_API_KEY not found in environment")
+        print("Please set your Google API key:")
+        print("  export GOOGLE_API_KEY='your-key-here'")
+        return
+    
+    # Parse forced perspectives if provided
+    forced_intents = None
+    if force_perspectives:
+        try:
+            forced_intents = [
+                QuestionIntent[p.upper()] for p in force_perspectives
+            ]
+        except KeyError as e:
+            print(f"\n❌ Error: Invalid perspective '{e.args[0]}'")
+            print(f"Valid perspectives: {', '.join(i.value for i in QuestionIntent)}")
+            return
+    
+    # Create orchestrator
+    orchestrator = MultiPerspectiveQADIOrchestrator(temperature_override=temperature)
+    
+    if temperature:
+        print(f"🌡️  Temperature override: {temperature}")
+    
+    start_time = time.time()
+    
+    try:
+        # Run analysis
+        result = await orchestrator.run_multi_perspective_analysis(
+            user_input,
+            max_perspectives=3,
+            force_perspectives=forced_intents,
+        )
+        
+        # Display intent detection
+        intent_detector = IntentDetector()
+        intent_result = intent_detector.detect_intent(user_input)
+        display_intent_detection(intent_result, result.perspectives_used)
+        
+        # Display results based on mode
+        if show_all_perspectives or len(result.perspective_results) == 1:
+            # Show all perspective details
+            for i, pr in enumerate(result.perspective_results):
+                display_perspective_result(pr, is_primary=(i == 0))
+        else:
+            # Show only primary perspective in detail
+            if result.perspective_results:
+                display_perspective_result(result.perspective_results[0], is_primary=True)
+            
+            # Brief summary of other perspectives
+            if len(result.perspective_results) > 1:
+                print(f"\n📊 Additional Perspectives Analyzed:")
+                for pr in result.perspective_results[1:]:
+                    emoji_map = {
+                        QuestionIntent.ENVIRONMENTAL: "🌍",
+                        QuestionIntent.PERSONAL: "👤",
+                        QuestionIntent.TECHNICAL: "💻",
+                        QuestionIntent.BUSINESS: "💼",
+                        QuestionIntent.SCIENTIFIC: "🔬",
+                        QuestionIntent.PHILOSOPHICAL: "🤔",
+                        QuestionIntent.GENERAL: "📋",
+                    }
+                    emoji = emoji_map.get(pr.perspective, "📋")
+                    print(f"\n{emoji} {pr.perspective.value.title()}: {pr.result.core_question}")
+        
+        # Always show synthesis when multiple perspectives
+        if len(result.perspective_results) > 1:
+            display_synthesis(result)
+        
+        # Summary statistics
+        elapsed_time = time.time() - start_time
+        print(f"\n{'─' * 70}")
+        print(f"✅ Analysis completed in {elapsed_time:.1f}s")
+        print(f"💰 Total LLM cost: ${result.total_llm_cost:.4f}")
+        print(f"🔍 Perspectives used: {len(result.perspective_results)}")
+        
+    except Exception as e:
+        print(f"\n❌ Error: {e}")
+        import traceback
+        traceback.print_exc()
+
+
+def main() -> None:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Run multi-perspective QADI analysis with automatic intent detection"
+    )
+    parser.add_argument("input", help="Your question, problem, or topic to analyze")
+    parser.add_argument(
+        "--temperature",
+        "-t",
+        type=float,
+        help="Temperature for hypothesis generation (0.0-2.0)",
+        default=None,
+    )
+    parser.add_argument(
+        "--perspectives",
+        "-p",
+        type=str,
+        help="Force specific perspectives (comma-separated: environmental,personal,technical,business,scientific,philosophical)",
+        default=None,
+    )
+    parser.add_argument(
+        "--show-all",
+        "-a",
+        action="store_true",
+        help="Show detailed results from all perspectives (default: show synthesis)",
+    )
+    
+    args = parser.parse_args()
+    
+    # Validate temperature
+    if args.temperature is not None and not 0.0 <= args.temperature <= 2.0:
+        print(f"Error: Temperature must be between 0.0 and 2.0 (got {args.temperature})")
+        sys.exit(1)
+    
+    # Parse perspectives
+    force_perspectives = None
+    if args.perspectives:
+        force_perspectives = [p.strip() for p in args.perspectives.split(",")]
+    
+    # Load environment variables
+    try:
+        from dotenv import load_dotenv
+        load_dotenv()
+    except ImportError:
+        pass
+    
+    # Initialize and run
+    async def main_async():
+        # Initialize LLM providers before running analysis
+        await setup_llm_providers(
+            google_api_key=os.getenv("GOOGLE_API_KEY"),
+        )
+        
+        await run_multi_perspective_analysis(
+            args.input,
+            temperature=args.temperature,
+            force_perspectives=force_perspectives,
+            show_all_perspectives=args.show_all,
+        )
+    
+    asyncio.run(main_async())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mad_spark_alt/core/intent_detector.py
+++ b/src/mad_spark_alt/core/intent_detector.py
@@ -1,0 +1,219 @@
+"""
+Intent Detection for Multi-Perspective QADI Analysis
+
+This module detects the primary intent behind user questions to enable
+appropriate perspective selection for QADI analysis.
+"""
+
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Dict, List, Tuple
+
+
+class QuestionIntent(Enum):
+    """Primary intents for questions."""
+    
+    ENVIRONMENTAL = "environmental"
+    PERSONAL = "personal"
+    TECHNICAL = "technical"
+    BUSINESS = "business"
+    SCIENTIFIC = "scientific"
+    PHILOSOPHICAL = "philosophical"
+    GENERAL = "general"
+
+
+@dataclass
+class IntentResult:
+    """Result of intent detection."""
+    
+    primary_intent: QuestionIntent
+    confidence: float  # 0.0 to 1.0
+    secondary_intents: List[QuestionIntent]
+    keywords_matched: List[str]
+
+
+class IntentDetector:
+    """Detects the primary intent behind user questions."""
+    
+    def __init__(self) -> None:
+        """Initialize the detector with intent patterns."""
+        
+        # Intent patterns with keywords and phrases
+        self.intent_patterns: Dict[QuestionIntent, Dict[str, List[str]]] = {
+            QuestionIntent.ENVIRONMENTAL: {
+                "keywords": [
+                    "environment", "environmental", "sustainable", "sustainability",
+                    "plastic", "waste", "pollution", "climate", "carbon", "emissions",
+                    "recycle", "recycling", "green", "eco", "ecological", "nature",
+                    "conservation", "biodegradable", "renewable", "energy", "solar",
+                    "wind", "ocean", "forest", "ecosystem", "habitat", "species"
+                ],
+                "phrases": [
+                    "reduce waste", "save the planet", "environmental impact",
+                    "climate change", "global warming", "carbon footprint",
+                    "go green", "eco-friendly", "renewable energy", "protect nature"
+                ]
+            },
+            QuestionIntent.PERSONAL: {
+                "keywords": [
+                    "I", "me", "my", "myself", "personal", "individual", "lifestyle",
+                    "habit", "daily", "routine", "health", "wellness", "self",
+                    "improve", "change", "grow", "learn", "develop", "mindset"
+                ],
+                "phrases": [
+                    "how can I", "what should I", "personal development",
+                    "self improvement", "my life", "individual action",
+                    "lifestyle change", "personal growth", "daily routine"
+                ]
+            },
+            QuestionIntent.TECHNICAL: {
+                "keywords": [
+                    "build", "code", "program", "software", "hardware", "system",
+                    "algorithm", "database", "API", "framework", "technology",
+                    "implement", "develop", "architecture", "infrastructure",
+                    "debug", "optimize", "deploy", "scale", "security", "network"
+                ],
+                "phrases": [
+                    "how to build", "technical implementation", "system design",
+                    "software development", "code architecture", "tech stack",
+                    "programming solution", "technical approach"
+                ]
+            },
+            QuestionIntent.BUSINESS: {
+                "keywords": [
+                    "business", "company", "organization", "profit", "revenue",
+                    "market", "customer", "strategy", "growth", "sales", "marketing",
+                    "ROI", "investment", "competitive", "brand", "enterprise",
+                    "startup", "economy", "financial", "commercial", "corporate"
+                ],
+                "phrases": [
+                    "business strategy", "market analysis", "revenue growth",
+                    "customer acquisition", "competitive advantage", "ROI analysis",
+                    "business model", "market share", "profit margin"
+                ]
+            },
+            QuestionIntent.SCIENTIFIC: {
+                "keywords": [
+                    "science", "scientific", "research", "study", "experiment",
+                    "data", "analysis", "hypothesis", "theory", "evidence",
+                    "biology", "chemistry", "physics", "mathematics", "statistics",
+                    "methodology", "peer-review", "publication", "discovery"
+                ],
+                "phrases": [
+                    "scientific method", "research study", "data analysis",
+                    "experimental design", "hypothesis testing", "evidence-based",
+                    "scientific research", "peer-reviewed", "empirical data"
+                ]
+            },
+            QuestionIntent.PHILOSOPHICAL: {
+                "keywords": [
+                    "philosophy", "philosophical", "ethics", "ethical", "moral",
+                    "meaning", "purpose", "value", "belief", "principle", "wisdom",
+                    "truth", "existence", "consciousness", "reality", "society",
+                    "justice", "freedom", "humanity", "virtue", "good", "evil"
+                ],
+                "phrases": [
+                    "meaning of", "purpose of", "ethical implications",
+                    "moral responsibility", "philosophical question", "value system",
+                    "greater good", "human nature", "societal impact"
+                ]
+            }
+        }
+        
+    def detect_intent(self, question: str) -> IntentResult:
+        """
+        Detect the primary intent of a question.
+        
+        Args:
+            question: The user's question or input
+            
+        Returns:
+            IntentResult with primary and secondary intents
+        """
+        question_lower = question.lower()
+        intent_scores: Dict[QuestionIntent, Tuple[float, List[str]]] = {}
+        
+        # Calculate scores for each intent
+        for intent, patterns in self.intent_patterns.items():
+            score = 0.0
+            matched_keywords = []
+            
+            # Check keywords (with word boundaries)
+            for keyword in patterns["keywords"]:
+                if re.search(rf'\b{re.escape(keyword)}\b', question_lower):
+                    score += 1.0
+                    matched_keywords.append(keyword)
+            
+            # Check phrases (higher weight)
+            for phrase in patterns["phrases"]:
+                if phrase in question_lower:
+                    score += 2.0
+                    matched_keywords.append(phrase)
+            
+            # Normalize score - use a more reasonable normalization
+            # Don't expect all keywords to match, just a few good ones
+            if score > 0:
+                # Normalize based on actual matches, not total possible
+                normalized_score = min(score / 5.0, 1.0)  # 5 matches = 100% confidence
+            else:
+                normalized_score = 0.0
+            
+            intent_scores[intent] = (normalized_score, matched_keywords)
+        
+        # Sort intents by score
+        sorted_intents = sorted(
+            intent_scores.items(),
+            key=lambda x: x[1][0],
+            reverse=True
+        )
+        
+        # Determine primary intent
+        if sorted_intents[0][1][0] > 0.0:
+            primary_intent = sorted_intents[0][0]
+            confidence = sorted_intents[0][1][0]  # Already normalized
+            keywords_matched = sorted_intents[0][1][1]
+        else:
+            # No clear intent detected
+            primary_intent = QuestionIntent.GENERAL
+            confidence = 0.5
+            keywords_matched = []
+        
+        # Collect secondary intents (score > 0)
+        secondary_intents = [
+            intent for intent, (score, _) in sorted_intents[1:]
+            if score > 0.0
+        ][:2]  # Maximum 2 secondary intents
+        
+        return IntentResult(
+            primary_intent=primary_intent,
+            confidence=confidence,
+            secondary_intents=secondary_intents,
+            keywords_matched=keywords_matched
+        )
+    
+    def get_recommended_perspectives(
+        self, intent_result: IntentResult, max_perspectives: int = 3
+    ) -> List[QuestionIntent]:
+        """
+        Get recommended perspectives based on intent detection.
+        
+        Args:
+            intent_result: Result from detect_intent
+            max_perspectives: Maximum number of perspectives to recommend
+            
+        Returns:
+            List of recommended intents/perspectives
+        """
+        perspectives = [intent_result.primary_intent]
+        
+        # Add secondary intents if confidence is not too high
+        if intent_result.confidence < 0.8 and intent_result.secondary_intents:
+            perspectives.extend(intent_result.secondary_intents[:max_perspectives-1])
+        
+        # Always include business perspective for general questions
+        if (intent_result.primary_intent == QuestionIntent.GENERAL and 
+            QuestionIntent.BUSINESS not in perspectives):
+            perspectives.append(QuestionIntent.BUSINESS)
+        
+        return perspectives[:max_perspectives]

--- a/src/mad_spark_alt/core/intent_detector.py
+++ b/src/mad_spark_alt/core/intent_detector.py
@@ -57,9 +57,9 @@ class IntentDetector:
             },
             QuestionIntent.PERSONAL: {
                 "keywords": [
-                    "I", "me", "my", "myself", "personal", "individual", "lifestyle",
+                    "myself", "personal", "personally", "individual", "lifestyle",
                     "habit", "daily", "routine", "health", "wellness", "self",
-                    "improve", "change", "grow", "learn", "develop", "mindset"
+                    "mindset", "behavior", "practice", "motivation"
                 ],
                 "phrases": [
                     "how can I", "what should I", "personal development",

--- a/src/mad_spark_alt/core/multi_perspective_orchestrator.py
+++ b/src/mad_spark_alt/core/multi_perspective_orchestrator.py
@@ -1,0 +1,530 @@
+"""
+Multi-Perspective QADI Orchestrator
+
+This module extends the QADI methodology to provide analysis from multiple
+relevant perspectives based on question intent detection.
+"""
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from .intent_detector import IntentDetector, QuestionIntent
+from .interfaces import GeneratedIdea, ThinkingMethod
+from .llm_provider import LLMRequest, llm_manager
+from .multi_perspective_prompts import MultiPerspectivePrompts
+from .qadi_prompts import PHASE_HYPERPARAMETERS, calculate_hypothesis_score
+from .simple_qadi_orchestrator import HypothesisScore, SimpleQADIResult
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PerspectiveResult:
+    """Result from a single perspective's QADI analysis."""
+    
+    perspective: QuestionIntent
+    result: SimpleQADIResult
+    relevance_score: float  # How relevant this perspective is
+
+
+@dataclass
+class MultiPerspectiveQADIResult:
+    """Combined result from multi-perspective QADI analysis."""
+    
+    # Intent detection results
+    primary_intent: QuestionIntent
+    intent_confidence: float
+    keywords_matched: List[str]
+    
+    # Perspective results
+    perspective_results: List[PerspectiveResult]
+    
+    # Synthesized results
+    synthesized_answer: str
+    synthesized_action_plan: List[str]
+    best_hypothesis: Tuple[str, QuestionIntent]  # (hypothesis, from_perspective)
+    
+    # Metadata
+    total_llm_cost: float = 0.0
+    perspectives_used: List[QuestionIntent] = field(default_factory=list)
+    
+    # For backward compatibility
+    synthesized_ideas: List[GeneratedIdea] = field(default_factory=list)
+
+
+class MultiPerspectiveQADIOrchestrator:
+    """
+    Orchestrator for multi-perspective QADI analysis.
+    
+    Detects question intent and runs QADI from multiple relevant perspectives,
+    then synthesizes the results into a comprehensive answer.
+    """
+    
+    def __init__(self, temperature_override: Optional[float] = None) -> None:
+        """
+        Initialize the orchestrator.
+        
+        Args:
+            temperature_override: Optional temperature override for hypothesis generation
+        """
+        self.intent_detector = IntentDetector()
+        self.prompts = MultiPerspectivePrompts()
+        self.temperature_override = temperature_override
+    
+    async def run_multi_perspective_analysis(
+        self,
+        user_input: str,
+        max_perspectives: int = 3,
+        force_perspectives: Optional[List[QuestionIntent]] = None,
+    ) -> MultiPerspectiveQADIResult:
+        """
+        Run multi-perspective QADI analysis.
+        
+        Args:
+            user_input: The user's question or input
+            max_perspectives: Maximum number of perspectives to analyze
+            force_perspectives: Optional list of perspectives to use (overrides detection)
+            
+        Returns:
+            MultiPerspectiveQADIResult with analysis from multiple perspectives
+        """
+        # Detect intent if not forced
+        if force_perspectives:
+            perspectives = force_perspectives
+            intent_result = self.intent_detector.detect_intent(user_input)
+            primary_intent = perspectives[0] if perspectives else QuestionIntent.GENERAL
+        else:
+            intent_result = self.intent_detector.detect_intent(user_input)
+            perspectives = self.intent_detector.get_recommended_perspectives(
+                intent_result, max_perspectives
+            )
+            primary_intent = intent_result.primary_intent
+        
+        logger.info(
+            f"Detected intent: {primary_intent} (confidence: {intent_result.confidence:.2f})"
+        )
+        logger.info(f"Using perspectives: {[p.value for p in perspectives]}")
+        
+        # Run QADI for each perspective in parallel
+        perspective_tasks = []
+        for perspective in perspectives:
+            task = self._run_perspective_analysis(user_input, perspective)
+            perspective_tasks.append(task)
+        
+        perspective_results = await asyncio.gather(*perspective_tasks)
+        
+        # Calculate relevance scores
+        scored_results = []
+        for i, (perspective, result) in enumerate(zip(perspectives, perspective_results)):
+            if result:  # Only include successful results
+                relevance = 1.0 if i == 0 else 0.8 - (i * 0.1)  # Primary gets 1.0
+                scored_results.append(PerspectiveResult(perspective, result, relevance))
+        
+        # Synthesize results
+        synthesized = await self._synthesize_results(user_input, scored_results)
+        
+        # Calculate total cost
+        total_cost = sum(pr.result.total_llm_cost for pr in scored_results)
+        total_cost += synthesized.get("synthesis_cost", 0.0)
+        
+        # Create combined result
+        return MultiPerspectiveQADIResult(
+            primary_intent=primary_intent,
+            intent_confidence=intent_result.confidence,
+            keywords_matched=intent_result.keywords_matched,
+            perspective_results=scored_results,
+            synthesized_answer=synthesized["answer"],
+            synthesized_action_plan=synthesized["action_plan"],
+            best_hypothesis=synthesized["best_hypothesis"],
+            total_llm_cost=total_cost,
+            perspectives_used=perspectives,
+            synthesized_ideas=self._collect_all_ideas(scored_results),
+        )
+    
+    async def _run_perspective_analysis(
+        self, user_input: str, perspective: QuestionIntent
+    ) -> Optional[SimpleQADIResult]:
+        """Run QADI analysis from a single perspective."""
+        try:
+            logger.info(f"Running {perspective.value} perspective analysis")
+            
+            result = SimpleQADIResult(
+                core_question="",
+                hypotheses=[],
+                hypothesis_scores=[],
+                final_answer="",
+                action_plan=[],
+                verification_examples=[],
+                verification_conclusion="",
+            )
+            
+            # Phase 1: Questioning
+            prompt = self.prompts.get_questioning_prompt(user_input, perspective)
+            question, cost = await self._run_llm_phase(prompt, "questioning")
+            result.core_question = self._extract_question(question)
+            result.total_llm_cost += cost
+            
+            # Phase 2: Abduction (Hypothesis Generation)
+            prompt = self.prompts.get_abduction_prompt(
+                user_input, result.core_question, perspective
+            )
+            hypotheses_text, cost = await self._run_llm_phase(
+                prompt, "abduction", use_temperature_override=True
+            )
+            result.hypotheses = self._extract_hypotheses(hypotheses_text)
+            result.total_llm_cost += cost
+            
+            # Phase 3: Deduction (Evaluation)
+            if not result.hypotheses:
+                logger.error(f"No hypotheses generated for {perspective.value} perspective")
+                return None
+                
+            hypotheses_formatted = "\n".join(
+                [f"H{i+1}: {h}" for i, h in enumerate(result.hypotheses)]
+            )
+            prompt = self.prompts.get_deduction_prompt(
+                user_input, result.core_question, hypotheses_formatted, perspective
+            )
+            deduction_text, cost = await self._run_llm_phase(prompt, "deduction")
+            
+            # Parse deduction results
+            deduction_parsed = self._parse_deduction_results(
+                deduction_text, len(result.hypotheses)
+            )
+            result.hypothesis_scores = deduction_parsed["scores"]
+            result.final_answer = deduction_parsed["answer"]
+            result.action_plan = deduction_parsed["action_plan"]
+            result.total_llm_cost += cost
+            
+            # Phase 4: Induction (Verification)
+            prompt = self.prompts.get_induction_prompt(
+                user_input, result.core_question, result.final_answer, perspective
+            )
+            induction_text, cost = await self._run_llm_phase(prompt, "induction")
+            
+            induction_parsed = self._parse_induction_results(induction_text)
+            result.verification_examples = induction_parsed["examples"]
+            result.verification_conclusion = induction_parsed["conclusion"]
+            result.total_llm_cost += cost
+            
+            return result
+            
+        except Exception as e:
+            logger.error(f"Failed {perspective.value} perspective analysis: {e}")
+            import traceback
+            logger.error(f"Traceback: {traceback.format_exc()}")
+            return None
+    
+    async def _run_llm_phase(
+        self,
+        prompt: str,
+        phase: str,
+        use_temperature_override: bool = False,
+    ) -> Tuple[str, float]:
+        """Run a single LLM phase with appropriate parameters."""
+        hyperparams = PHASE_HYPERPARAMETERS.get(phase, PHASE_HYPERPARAMETERS["questioning"])
+        
+        # Apply temperature override for abduction if specified
+        if use_temperature_override and self.temperature_override is not None and phase == "abduction":
+            temperature = self.temperature_override
+        else:
+            temperature = hyperparams["temperature"]
+        
+        request = LLMRequest(
+            user_prompt=prompt,
+            temperature=temperature,
+            max_tokens=int(hyperparams["max_tokens"]),
+            top_p=hyperparams.get("top_p", 0.9),
+        )
+        
+        response = await llm_manager.generate(request)
+        return response.content.strip(), response.cost
+    
+    def _extract_question(self, text: str) -> str:
+        """Extract core question from LLM response."""
+        import re
+        
+        match = re.search(r"Q:\s*(.+)", text, re.DOTALL)
+        if match:
+            # Take only the first line of the match
+            return match.group(1).strip().split('\n')[0].strip()
+        
+        # Fallback: use first non-empty line
+        for line in text.split("\n"):
+            if line.strip() and not line.strip().startswith(("Think about:", "-", "*")):
+                return line.strip()
+        
+        return "What is the core challenge here?"
+    
+    def _extract_hypotheses(self, text: str) -> List[str]:
+        """Extract hypotheses from LLM response."""
+        import re
+        
+        hypotheses = []
+        lines = text.split("\n")
+        
+        current_hypothesis = ""
+        current_index = None
+        
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            
+            # Check if line starts with H1:, H2:, or H3:
+            match = re.match(r"H([123]):\s*(.+)", line)
+            if match:
+                # Save previous hypothesis if we have one
+                if current_index is not None and current_hypothesis.strip():
+                    hypotheses.append(current_hypothesis.strip())
+                
+                # Start new hypothesis
+                current_index = int(match.group(1))
+                current_hypothesis = match.group(2)
+            elif current_index is not None:
+                # Continue building current hypothesis
+                current_hypothesis += " " + line
+        
+        # Don't forget the last hypothesis
+        if current_index is not None and current_hypothesis.strip():
+            hypotheses.append(current_hypothesis.strip())
+        
+        # If no hypotheses found with H1: format, try numbered format
+        if not hypotheses:
+            for line in lines:
+                match = re.match(r"^\d+\.\s*(.+)", line.strip())
+                if match:
+                    hypotheses.append(match.group(1).strip())
+        
+        return hypotheses[:3]  # Maximum 3 hypotheses
+    
+    def _parse_deduction_results(self, text: str, num_hypotheses: int) -> Dict[str, Any]:
+        """Parse deduction phase results."""
+        import re
+        
+        # Extract scores for each hypothesis
+        scores = []
+        for i in range(num_hypotheses):
+            score = self._extract_hypothesis_scores(text, i + 1)
+            scores.append(score)
+        
+        # Extract answer
+        answer_match = re.search(r"ANSWER:\s*(.+?)(?=Action Plan:|$)", text, re.DOTALL)
+        answer = answer_match.group(1).strip() if answer_match else ""
+        
+        # Extract action plan
+        action_plan = []
+        plan_match = re.search(r"Action Plan:\s*(.+?)$", text, re.DOTALL)
+        if plan_match:
+            plan_text = plan_match.group(1).strip()
+            # Extract numbered items
+            plan_items = re.findall(r"\d+\.\s*(.+?)(?=\d+\.|$)", plan_text, re.DOTALL)
+            action_plan = [item.strip() for item in plan_items]
+        
+        return {
+            "scores": scores,
+            "answer": answer,
+            "action_plan": action_plan,
+        }
+    
+    def _extract_hypothesis_scores(self, text: str, hypothesis_num: int) -> HypothesisScore:
+        """Extract scores for a specific hypothesis."""
+        import re
+        
+        # Find the hypothesis section
+        pattern = rf"H{hypothesis_num}:.*?(?=H{hypothesis_num + 1}:|ANSWER:|$)"
+        match = re.search(pattern, text, re.DOTALL)
+        
+        if not match:
+            return HypothesisScore(0.5, 0.5, 0.5, 0.5, 0.5, 0.5)
+        
+        section = match.group(0)
+        
+        # Extract individual scores - flexible matching
+        def extract_score(patterns: List[str], text: str) -> float:
+            for pattern in patterns:
+                match = re.search(pattern, text, re.IGNORECASE)
+                if match:
+                    try:
+                        return float(match.group(1))
+                    except:
+                        pass
+            return 0.5
+        
+        # Different patterns for different perspectives
+        scores_dict = {}
+        
+        # Try to extract based on common patterns
+        score_patterns = [
+            r":\s*([0-9.]+)\s*-",  # ": 0.8 -"
+            r":\s*([0-9.]+)",      # ": 0.8"
+            r"\(([0-9.]+)\)",      # "(0.8)"
+        ]
+        
+        # Map various criteria names to standard ones
+        criteria_mappings = {
+            "novelty": ["novelty", "innovation", "environmental impact", "personal impact", 
+                       "technical innovation", "business value", "scientific validity", 
+                       "ethical soundness"],
+            "impact": ["impact", "sustainability", "ease of adoption", "implementation complexity",
+                      "market impact", "research impact", "societal benefit"],
+            "cost": ["cost", "resource efficiency", "time investment", "cost efficiency",
+                    "resource requirements"],
+            "feasibility": ["feasibility", "implementation feasibility", "scalability",
+                           "implementation speed", "practical application", "universal applicability"],
+            "risks": ["risks", "ecosystem benefits", "long-term benefits", "maintainability",
+                     "risk level", "peer acceptance", "human flourishing"],
+        }
+        
+        # Extract scores with flexible matching
+        for standard_key, variations in criteria_mappings.items():
+            score = 0.5  # default
+            for variation in variations:
+                patterns = [f"{variation}{p}" for p in score_patterns]
+                extracted = extract_score(patterns, section)
+                if extracted != 0.5:
+                    score = extracted
+                    break
+            scores_dict[standard_key] = score
+        
+        # Calculate overall
+        overall = calculate_hypothesis_score(scores_dict)
+        
+        return HypothesisScore(
+            novelty=scores_dict.get("novelty", 0.5),
+            impact=scores_dict.get("impact", 0.5),
+            cost=scores_dict.get("cost", 0.5),
+            feasibility=scores_dict.get("feasibility", 0.5),
+            risks=scores_dict.get("risks", 0.5),
+            overall=overall,
+        )
+    
+    def _parse_induction_results(self, text: str) -> Dict[str, Any]:
+        """Parse induction phase results."""
+        import re
+        
+        # Extract examples
+        examples = []
+        example_matches = re.findall(r"\d+\.\s*(.+?)(?=\d+\.|Conclusion:|$)", text, re.DOTALL)
+        examples = [match.strip() for match in example_matches]
+        
+        # Extract conclusion
+        conclusion_match = re.search(r"Conclusion:\s*(.+?)$", text, re.DOTALL)
+        conclusion = conclusion_match.group(1).strip() if conclusion_match else ""
+        
+        return {
+            "examples": examples,
+            "conclusion": conclusion,
+        }
+    
+    async def _synthesize_results(
+        self, user_input: str, perspective_results: List[PerspectiveResult]
+    ) -> Dict[str, Any]:
+        """Synthesize results from multiple perspectives."""
+        if not perspective_results:
+            return {
+                "answer": "Unable to generate analysis.",
+                "action_plan": [],
+                "best_hypothesis": ("No hypotheses generated", QuestionIntent.GENERAL),
+                "synthesis_cost": 0.0,
+            }
+        
+        # Find best hypothesis across all perspectives
+        best_hypothesis = ("", QuestionIntent.GENERAL)
+        best_score = -1.0
+        
+        for pr in perspective_results:
+            for i, (hyp, score) in enumerate(zip(pr.result.hypotheses, pr.result.hypothesis_scores)):
+                weighted_score = score.overall * pr.relevance_score
+                if weighted_score > best_score:
+                    best_score = weighted_score
+                    best_hypothesis = (hyp, pr.perspective)
+        
+        # Create synthesis prompt
+        perspectives_summary = "\n\n".join([
+            f"**{pr.perspective.value.title()} Perspective:**\n"
+            f"Core Question: {pr.result.core_question}\n"
+            f"Key Answer: {pr.result.final_answer[:200]}..."
+            for pr in perspective_results
+        ])
+        
+        synthesis_prompt = f"""Based on multiple perspective analyses of the user's question, synthesize a comprehensive answer.
+
+User's original question:
+{user_input}
+
+Perspectives analyzed:
+{perspectives_summary}
+
+Best hypothesis identified:
+"{best_hypothesis[0]}" (from {best_hypothesis[1].value} perspective)
+
+Create a synthesized answer that:
+1. Addresses the user's question comprehensively
+2. Integrates insights from all perspectives
+3. Highlights the most practical and impactful recommendations
+4. Is concise and actionable
+
+Format:
+SYNTHESIS: [Your comprehensive answer integrating all perspectives]
+
+INTEGRATED ACTION PLAN:
+1. [Most important action combining insights]
+2. [Second priority action]
+3. [Third priority action]
+"""
+        
+        # Run synthesis
+        response_text, cost = await self._run_llm_phase(synthesis_prompt, "questioning")
+        
+        # Parse synthesis
+        import re
+        
+        synthesis_match = re.search(r"SYNTHESIS:\s*(.+?)(?=INTEGRATED ACTION PLAN:|$)", 
+                                  response_text, re.DOTALL)
+        synthesized_answer = synthesis_match.group(1).strip() if synthesis_match else perspectives_summary
+        
+        # Extract integrated action plan
+        action_plan = []
+        plan_match = re.search(r"INTEGRATED ACTION PLAN:\s*(.+?)$", response_text, re.DOTALL)
+        if plan_match:
+            plan_text = plan_match.group(1).strip()
+            plan_items = re.findall(r"\d+\.\s*(.+?)(?=\d+\.|$)", plan_text, re.DOTALL)
+            action_plan = [item.strip() for item in plan_items]
+        
+        # If no synthesis, use best perspective's action plan
+        if not action_plan and perspective_results:
+            action_plan = perspective_results[0].result.action_plan[:3]
+        
+        return {
+            "answer": synthesized_answer,
+            "action_plan": action_plan,
+            "best_hypothesis": best_hypothesis,
+            "synthesis_cost": cost,
+        }
+    
+    def _collect_all_ideas(self, perspective_results: List[PerspectiveResult]) -> List[GeneratedIdea]:
+        """Collect all generated ideas from all perspectives."""
+        all_ideas = []
+        
+        for pr in perspective_results:
+            for i, hyp in enumerate(pr.result.hypotheses):
+                all_ideas.append(
+                    GeneratedIdea(
+                        content=hyp,
+                        thinking_method=ThinkingMethod.ABDUCTION,
+                        agent_name=f"MultiPerspective-{pr.perspective.value}",
+                        generation_prompt=pr.result.core_question,
+                        confidence_score=pr.result.hypothesis_scores[i].overall if i < len(pr.result.hypothesis_scores) else 0.5,
+                        reasoning=f"Generated from {pr.perspective.value} perspective",
+                        metadata={
+                            "perspective": pr.perspective.value,
+                            "hypothesis_index": i,
+                            "relevance_score": pr.relevance_score,
+                        },
+                    )
+                )
+        
+        return all_ideas

--- a/src/mad_spark_alt/core/multi_perspective_prompts.py
+++ b/src/mad_spark_alt/core/multi_perspective_prompts.py
@@ -1,0 +1,233 @@
+"""
+Multi-Perspective QADI Prompts
+
+This module provides perspective-specific prompts for the QADI methodology,
+enabling analysis from environmental, personal, technical, business, scientific,
+and philosophical viewpoints.
+"""
+
+from typing import Dict
+
+from .intent_detector import QuestionIntent
+
+
+class MultiPerspectivePrompts:
+    """Perspective-specific prompts for QADI analysis."""
+    
+    def __init__(self) -> None:
+        """Initialize with perspective-specific prompt templates."""
+        self.perspective_prompts = {
+            QuestionIntent.ENVIRONMENTAL: {
+                "role": "environmental sustainability expert",
+                "question_focus": "ecological impact and sustainable solutions",
+                "hypothesis_focus": "environmentally responsible approaches",
+                "evaluation_criteria": "environmental benefit, feasibility, and long-term sustainability",
+                "verification_focus": "real-world environmental success stories"
+            },
+            QuestionIntent.PERSONAL: {
+                "role": "personal development coach",
+                "question_focus": "individual actions and personal growth",
+                "hypothesis_focus": "practical personal strategies",
+                "evaluation_criteria": "personal impact, ease of adoption, and lifestyle compatibility",
+                "verification_focus": "individual success stories and behavioral changes"
+            },
+            QuestionIntent.TECHNICAL: {
+                "role": "technical solutions architect",
+                "question_focus": "technical implementation and system design",
+                "hypothesis_focus": "technological solutions and architectures",
+                "evaluation_criteria": "technical feasibility, scalability, and innovation",
+                "verification_focus": "successful technical implementations"
+            },
+            QuestionIntent.BUSINESS: {
+                "role": "strategic business consultant",
+                "question_focus": "business value and strategic objectives",
+                "hypothesis_focus": "business strategies and operational improvements",
+                "evaluation_criteria": "ROI, market impact, and competitive advantage",
+                "verification_focus": "business case studies and market examples"
+            },
+            QuestionIntent.SCIENTIFIC: {
+                "role": "research scientist",
+                "question_focus": "scientific understanding and evidence-based solutions",
+                "hypothesis_focus": "research-backed approaches and methodologies",
+                "evaluation_criteria": "scientific validity, empirical support, and reproducibility",
+                "verification_focus": "peer-reviewed studies and research findings"
+            },
+            QuestionIntent.PHILOSOPHICAL: {
+                "role": "philosophical thinker",
+                "question_focus": "ethical implications and fundamental principles",
+                "hypothesis_focus": "value-based approaches and ethical frameworks",
+                "evaluation_criteria": "ethical soundness, societal benefit, and principled consistency",
+                "verification_focus": "philosophical precedents and ethical applications"
+            },
+            QuestionIntent.GENERAL: {
+                "role": "comprehensive analyst",
+                "question_focus": "core challenges and opportunities",
+                "hypothesis_focus": "diverse solution approaches",
+                "evaluation_criteria": "overall effectiveness and practical implementation",
+                "verification_focus": "varied real-world applications"
+            }
+        }
+    
+    def get_questioning_prompt(self, user_input: str, perspective: QuestionIntent) -> str:
+        """Get perspective-specific questioning prompt."""
+        config = self.perspective_prompts[perspective]
+        return f"""As a {config['role']}, identify THE single most important question focusing on {config['question_focus']}.
+
+User's input:
+{user_input}
+
+Think about:
+- What is the core {perspective.value} challenge or opportunity here?
+- What question would provide maximum insight from a {perspective.value} perspective?
+- What specific aspect needs the most attention?
+
+Output exactly ONE core question.
+Format: "Q: [Your core question]"
+"""
+    
+    def get_abduction_prompt(
+        self, user_input: str, core_question: str, perspective: QuestionIntent
+    ) -> str:
+        """Get perspective-specific hypothesis generation prompt."""
+        config = self.perspective_prompts[perspective]
+        return f"""As a {config['role']}, generate 3 specific hypotheses focusing on {config['hypothesis_focus']}.
+
+Core Question: {core_question}
+
+User's original input:
+{user_input}
+
+Each hypothesis should:
+- Directly answer the question from a {perspective.value} perspective
+- Be specific and actionable
+- Focus on {config['hypothesis_focus']}
+
+Format:
+H1: [First hypothesis]
+H2: [Second hypothesis]
+H3: [Third hypothesis]
+"""
+    
+    def get_deduction_prompt(
+        self, user_input: str, core_question: str, hypotheses: str, perspective: QuestionIntent
+    ) -> str:
+        """Get perspective-specific evaluation prompt."""
+        config = self.perspective_prompts[perspective]
+        
+        # Adjust criteria labels based on perspective
+        criteria = self._get_perspective_criteria(perspective)
+        
+        # Extract criteria names for the format template
+        criteria_lines = [line.strip() for line in criteria.split('\n') if line.strip() and ':' in line]
+        criteria_names = []
+        for line in criteria_lines:
+            name = line.split(':')[0].replace('-', '').strip()
+            criteria_names.append(name)
+        
+        # Build the format template
+        criteria_format = "\n  ".join([f"* {name}: [score] - [brief explanation]" for name in criteria_names])
+        
+        return f"""As a {config['role']}, evaluate each hypothesis based on {config['evaluation_criteria']}.
+
+Core Question: {core_question}
+
+Hypotheses to evaluate:
+{hypotheses}
+
+User's original context:
+{user_input}
+
+Score each hypothesis from 0.0 to 1.0 on:
+{criteria}
+
+Format:
+Analysis:
+- H1: 
+  {criteria_format}
+  * Overall: [calculated weighted score]
+
+- H2: 
+  [Same format as H1]
+
+- H3: 
+  [Same format as H1]
+
+ANSWER: [Your definitive answer from a {perspective.value} perspective]
+
+Action Plan:
+1. [First specific action from {perspective.value} perspective]
+2. [Second concrete action]
+3. [Third actionable step]
+"""
+    
+    def get_induction_prompt(
+        self, user_input: str, core_question: str, answer: str, perspective: QuestionIntent
+    ) -> str:
+        """Get perspective-specific verification prompt."""
+        config = self.perspective_prompts[perspective]
+        return f"""As a {config['role']}, verify the answer by examining {config['verification_focus']}.
+
+Core Question: {core_question}
+Our Answer: {answer}
+
+Original context:
+{user_input}
+
+Provide 3 examples that demonstrate this answer's validity:
+
+Format:
+Verification:
+1. [Real-world example from {perspective.value} domain]
+2. [Different context where this {perspective.value} principle applies]
+3. [Future scenario where this would be effective]
+
+Conclusion: [Is this answer valid from a {perspective.value} perspective? Any limitations?]
+"""
+    
+    def _get_perspective_criteria(self, perspective: QuestionIntent) -> str:
+        """Get evaluation criteria tailored to each perspective."""
+        criteria_map = {
+            QuestionIntent.ENVIRONMENTAL: """- Environmental Impact: How much positive environmental change? (0=harmful, 1=highly beneficial)
+- Sustainability: How sustainable long-term? (0=unsustainable, 1=fully sustainable)
+- Resource Efficiency: How efficient with natural resources? (0=wasteful, 1=highly efficient)
+- Implementation Feasibility: How practical to implement? (0=very difficult, 1=easy)
+- Ecosystem Benefits: Benefits to ecosystems/biodiversity? (0=none, 1=significant)""",
+            
+            QuestionIntent.PERSONAL: """- Personal Impact: How much positive personal change? (0=none, 1=transformative)
+- Ease of Adoption: How easy for individuals to adopt? (0=very difficult, 1=effortless)
+- Time Investment: Time required? (0=excessive, 1=minimal)
+- Cost to Individual: Financial cost? (0=expensive, 1=free/saves money)
+- Long-term Benefits: Sustained personal benefits? (0=temporary, 1=lasting)""",
+            
+            QuestionIntent.TECHNICAL: """- Technical Innovation: How innovative technically? (0=outdated, 1=cutting-edge)
+- Implementation Complexity: Technical difficulty? (0=extremely complex, 1=simple)
+- Scalability: How well does it scale? (0=doesn't scale, 1=infinitely scalable)
+- Performance: Technical performance/efficiency? (0=poor, 1=excellent)
+- Maintainability: Ease of maintenance? (0=nightmare, 1=self-maintaining)""",
+            
+            QuestionIntent.BUSINESS: """- Business Value: Revenue/profit potential? (0=loss-making, 1=highly profitable)
+- Market Impact: Market differentiation? (0=no impact, 1=market-defining)
+- Cost Efficiency: Resource requirements? (0=expensive, 1=cost-effective)
+- Implementation Speed: Time to market? (0=years, 1=immediate)
+- Risk Level: Business risks? (0=high risk, 1=low risk)""",
+            
+            QuestionIntent.SCIENTIFIC: """- Scientific Validity: Evidence support? (0=pseudoscience, 1=well-established)
+- Research Impact: Contribution to knowledge? (0=none, 1=breakthrough)
+- Reproducibility: Can findings be reproduced? (0=no, 1=highly reproducible)
+- Practical Application: Real-world applicability? (0=theoretical only, 1=immediately applicable)
+- Peer Acceptance: Scientific community support? (0=rejected, 1=widely accepted)""",
+            
+            QuestionIntent.PHILOSOPHICAL: """- Ethical Soundness: Alignment with ethical principles? (0=unethical, 1=highly ethical)
+- Societal Benefit: Benefit to society? (0=harmful, 1=transformative)
+- Universal Applicability: Works across cultures? (0=culturally specific, 1=universal)
+- Principled Consistency: Internal consistency? (0=contradictory, 1=coherent)
+- Human Flourishing: Promotes wellbeing? (0=diminishes, 1=enhances)""",
+            
+            QuestionIntent.GENERAL: """- Overall Effectiveness: How well does it work? (0=ineffective, 1=highly effective)
+- Practical Feasibility: How practical to implement? (0=impractical, 1=easily done)
+- Resource Requirements: Resources needed? (0=excessive, 1=minimal)
+- Adoption Potential: Likelihood of adoption? (0=unlikely, 1=certain)
+- Long-term Viability: Sustainable over time? (0=temporary, 1=permanent)"""
+        }
+        
+        return criteria_map.get(perspective, criteria_map[QuestionIntent.GENERAL])


### PR DESCRIPTION
## Summary
- Adds intelligent multi-perspective QADI analysis that detects question intent and provides appropriate perspectives
- Fixes the issue where general questions were always framed as business/consulting problems
- Provides more user-friendly and contextually appropriate responses

## Key Features
1. **Intent Detection**: Automatically detects question type (environmental, personal, technical, business, scientific, philosophical)
2. **Multi-Perspective Analysis**: Runs QADI from multiple relevant perspectives based on detected intent
3. **Synthesized Results**: Combines insights from different perspectives into comprehensive answers
4. **Manual Override**: Users can specify perspectives manually if desired

## Example
When asked "How can we reduce plastic waste?", the system now:
- Detects environmental intent (40% confidence)
- Provides environmental perspective analysis by default
- Can also include personal action perspective
- No longer forces business/ROI framing

## Implementation
- `intent_detector.py`: Keyword and phrase-based intent detection
- `multi_perspective_prompts.py`: Perspective-specific QADI prompts
- `multi_perspective_orchestrator.py`: Orchestrates multi-perspective analysis
- `qadi_multi_perspective.py`: New CLI script for multi-perspective analysis

## Testing
- Comprehensive unit tests for intent detection
- All tests passing
- Manual testing shows correct perspective selection

## Usage
```bash
# Automatic intent detection
uv run python qadi_multi_perspective.py "How can we reduce plastic waste?"

# Force specific perspectives
uv run python qadi_multi_perspective.py "Your question" --perspectives environmental,personal

# Show all perspective details
uv run python qadi_multi_perspective.py "Your question" --show-all
```