### PR TITLE
Fix genetic evolution producing duplicate ideas

### DIFF
--- a/qadi_simple.py
+++ b/qadi_simple.py
@@ -184,11 +184,11 @@ async def run_qadi_analysis(
                 # Create genetic algorithm instance
                 ga = GeneticAlgorithm()
                 
-                # Configure evolution
+                # Configure evolution with higher mutation rate for diversity
                 config = EvolutionConfig(
                     population_size=min(population, len(result.synthesized_ideas)),
                     generations=generations,
-                    mutation_rate=0.15,
+                    mutation_rate=0.3,  # Increased from default 0.1 to ensure diversity
                     crossover_rate=0.75,
                     elite_size=2,
                     selection_strategy=SelectionStrategy.TOURNAMENT,
@@ -211,16 +211,25 @@ async def run_qadi_analysis(
                 if evolution_result.success:
                     print(f"\n✅ Evolution completed in {evolution_time:.1f}s")
                     
-                    # Show top evolved ideas
+                    # Show top evolved ideas (deduplicated)
                     print("\n🏆 Top Evolved Ideas:\n")
                     
-                    top_individuals = sorted(
+                    # Deduplicate while maintaining order
+                    seen_contents = set()
+                    unique_individuals = []
+                    for ind in sorted(
                         evolution_result.final_population,
                         key=lambda x: x.overall_fitness,
                         reverse=True,
-                    )[:3]
+                    ):
+                        normalized_content = ind.idea.content.strip()
+                        if normalized_content not in seen_contents:
+                            seen_contents.add(normalized_content)
+                            unique_individuals.append(ind)
+                            if len(unique_individuals) >= 5:  # Show more unique ideas
+                                break
                     
-                    for i, individual in enumerate(top_individuals):
+                    for i, individual in enumerate(unique_individuals):
                         idea = individual.idea
                         print(f"### {i+1}. Evolved Idea (Fitness: {individual.overall_fitness:.3f})")
                         render_markdown(idea.content)

--- a/src/mad_spark_alt/evolution/genetic_algorithm.py
+++ b/src/mad_spark_alt/evolution/genetic_algorithm.py
@@ -559,9 +559,25 @@ class GeneticAlgorithm:
     def _extract_best_ideas(
         self, population: List[IndividualFitness], n: int
     ) -> List[GeneratedIdea]:
-        """Extract top N ideas from population."""
+        """Extract top N unique ideas from population."""
         sorted_pop = sorted(population, key=lambda x: x.overall_fitness, reverse=True)
-        return [ind.idea for ind in sorted_pop[:n]]
+        
+        # Deduplicate based on content
+        seen_contents = set()
+        unique_ideas = []
+        
+        for ind in sorted_pop:
+            # Normalize content for comparison (strip whitespace)
+            normalized_content = ind.idea.content.strip()
+            
+            if normalized_content not in seen_contents:
+                seen_contents.add(normalized_content)
+                unique_ideas.append(ind.idea)
+                
+                if len(unique_ideas) >= n:
+                    break
+        
+        return unique_ideas
 
     def _calculate_evolution_metrics(
         self,

--- a/src/mad_spark_alt/evolution/operators.py
+++ b/src/mad_spark_alt/evolution/operators.py
@@ -177,7 +177,7 @@ class MutationOperator(MutationInterface):
             context: Optional context for mutation
 
         Returns:
-            Mutated idea (or original if no mutation occurs)
+            Mutated idea (always returns a new object for proper tracking)
         """
         # Check if mutation should occur
         if random.random() < mutation_rate:
@@ -208,7 +208,26 @@ class MutationOperator(MutationInterface):
 
             return mutated_idea
         else:
-            return idea  # No mutation
+            # No mutation occurred, but still create a new object to ensure
+            # proper generation tracking and avoid duplicate references
+            unchanged_idea = GeneratedIdea(
+                content=idea.content,
+                thinking_method=idea.thinking_method,
+                agent_name=idea.agent_name,
+                generation_prompt=idea.generation_prompt,
+                confidence_score=idea.confidence_score,
+                reasoning=idea.reasoning,
+                parent_ideas=idea.parent_ideas,
+                metadata={
+                    **idea.metadata,
+                    "operator": "mutation",
+                    "mutation_type": "none",
+                    "mutation_rate": mutation_rate,
+                    "generation": idea.metadata.get("generation", 0) + 1,
+                },
+                timestamp=datetime.now(timezone.utc).isoformat(),
+            )
+            return unchanged_idea
 
     def _apply_mutation(self, content: str, mutation_type: str) -> str:
         """Apply specific mutation type to content using strategy pattern."""


### PR DESCRIPTION
## Summary
Fixes the issue where genetic evolution was showing identical "evolved" ideas in the results.

## Problem
When running evolution with `--evolve` flag, the top evolved ideas were often identical:
```
### 1. Evolved Idea (Fitness: 0.501)
Individuals can drastically reduce their personal plastic waste...

### 2. Evolved Idea (Fitness: 0.501)  
Individuals can drastically reduce their personal plastic waste...  # Same content\!

### 3. Evolved Idea (Fitness: 0.427)
Communities can significantly reduce plastic waste...
```

## Root Cause Analysis
1. **Low mutation rate (10%)**: 90% of the time, mutation returned the original idea object unchanged
2. **Cache system**: Identical ideas got the same cached fitness score
3. **No deduplication**: When extracting best ideas, duplicates weren't filtered out

## Solution
1. **Always create new idea objects** in mutation operator, even when no mutation occurs
2. **Add deduplication** to `_extract_best_ideas()` based on content
3. **Increase mutation rate** from 0.15 to 0.3 for `--evolve` flag
4. **Deduplicate display** in qadi_simple.py to show only unique evolved ideas

## Testing
- Added comprehensive tests in `test_evolution_diversity.py`
- Verified fix with plastic waste example - now shows unique evolved ideas
- Evolution properly tracks generation metadata and applies mutations

## Example Output (After Fix)
```
### 1. Evolved Idea (Fitness: 0.555)
By establishing and promoting community-centric circular economy hubs...
   _Generation: 2_

### 2. Evolved Idea (Fitness: 0.393)  
By establishing and promoting community-centric circular economy hubs... Scalability should be a key consideration.
   _Generation: 5_
```

Now shows unique ideas with visible mutations applied\!