### PR TITLE
Remove batch evaluation functionality

### DIFF
--- a/src/mad_spark_alt/core/unified_evaluator.py
+++ b/src/mad_spark_alt/core/unified_evaluator.py
@@ -110,44 +110,34 @@ class UnifiedEvaluator:
         context: str,
         core_question: Optional[str] = None,
         parallel: bool = True,
-        batch_size: int = 5,
+        batch_size: int = 5,  # Kept for backward compatibility but ignored
     ) -> List[HypothesisEvaluation]:
         """
-        Evaluate multiple hypotheses.
+        Evaluate multiple hypotheses using individual evaluations.
 
         Args:
             hypotheses: List of hypotheses to evaluate
             context: Context for evaluation
             core_question: Optional core question being answered
             parallel: Whether to evaluate in parallel
-            batch_size: Number of hypotheses to evaluate in a single LLM call
+            batch_size: Ignored (kept for backward compatibility)
 
         Returns:
             List of HypothesisEvaluation objects
         """
-        # If batch_size is 1 or we have very few hypotheses, use the original method
-        if batch_size <= 1 or len(hypotheses) <= 2:
-            if parallel:
-                import asyncio
+        if parallel:
+            import asyncio
 
-                tasks = [
-                    self.evaluate_hypothesis(h, context, core_question) for h in hypotheses
-                ]
-                return await asyncio.gather(*tasks)
+            tasks = [
+                self.evaluate_hypothesis(h, context, core_question) for h in hypotheses
+            ]
+            return await asyncio.gather(*tasks)
 
-            results = []
-            for hypothesis in hypotheses:
-                result = await self.evaluate_hypothesis(hypothesis, context, core_question)
-                results.append(result)
-            return results
-        
-        # Use batch evaluation for better performance
-        return await self.evaluate_batch(
-            hypotheses=hypotheses,
-            context=context,
-            core_question=core_question,
-            batch_size=batch_size
-        )
+        results = []
+        for hypothesis in hypotheses:
+            result = await self.evaluate_hypothesis(hypothesis, context, core_question)
+            results.append(result)
+        return results
 
     def _build_evaluation_prompt(
         self,
@@ -307,191 +297,6 @@ Risks: [score] - [one line explanation]
 
         return summary
     
-    async def evaluate_batch(
-        self,
-        hypotheses: List[str],
-        context: str,
-        core_question: Optional[str] = None,
-        batch_size: int = 5,
-        temperature: float = 0.3,
-    ) -> List[HypothesisEvaluation]:
-        """
-        Evaluate multiple hypotheses in batches using single LLM calls.
-        
-        Args:
-            hypotheses: List of hypotheses to evaluate
-            context: Context for evaluation
-            core_question: Optional core question being answered
-            batch_size: Number of hypotheses to evaluate per LLM call
-            temperature: LLM temperature for evaluation
-            
-        Returns:
-            List of HypothesisEvaluation objects
-        """
-        all_results: List[HypothesisEvaluation] = []
-        
-        # Process hypotheses in batches
-        for i in range(0, len(hypotheses), batch_size):
-            batch = hypotheses[i:i + batch_size]
-            batch_results = await self._evaluate_single_batch(
-                batch, context, core_question, temperature
-            )
-            all_results.extend(batch_results)
-        
-        return all_results
     
-    async def _evaluate_single_batch(
-        self,
-        batch: List[str],
-        context: str,
-        core_question: Optional[str],
-        temperature: float,
-    ) -> List[HypothesisEvaluation]:
-        """Evaluate a single batch of hypotheses in one LLM call."""
-        prompt = self._build_batch_evaluation_prompt(batch, context, core_question)
-        
-        try:
-            request = LLMRequest(
-                user_prompt=prompt,
-                temperature=temperature,
-                max_tokens=1500,  # Increased for multiple evaluations
-                top_p=0.9,
-            )
-            
-            response = await llm_manager.generate(request)
-            evaluations = self._parse_batch_evaluation_response(
-                response.content, batch, response.cost / len(batch), response.model
-            )
-            
-            return evaluations
-            
-        except Exception as e:
-            logger.exception("Failed to evaluate batch of %d hypotheses", len(batch))
-            # Return default evaluations for all hypotheses in batch
-            return [
-                HypothesisEvaluation(
-                    content=h,
-                    scores={
-                        "novelty": 0.5,
-                        "impact": 0.5,
-                        "cost": 0.5,
-                        "feasibility": 0.5,
-                        "risks": 0.5,
-                    },
-                    overall_score=0.5,
-                    explanations=dict.fromkeys(
-                        ["novelty", "impact", "cost", "feasibility", "risks"],
-                        f"Batch evaluation failed: {str(e)}"
-                    ),
-                    metadata={"error": str(e), "batch_evaluation": True},
-                )
-                for h in batch
-            ]
     
-    def _build_batch_evaluation_prompt(
-        self,
-        hypotheses: List[str],
-        context: str,
-        core_question: Optional[str] = None,
-    ) -> str:
-        """Build the evaluation prompt for a batch of hypotheses."""
-        question_context = f"\nCore Question: {core_question}" if core_question else ""
-        
-        hypotheses_text = "\n".join([
-            f"Hypothesis {i+1}: {h}" for i, h in enumerate(hypotheses)
-        ])
-        
-        return f"""As an analytical consultant, evaluate these hypotheses on a scale of 0.0 to 1.0 for each criterion.
-
-Context: {context}{question_context}
-
-{hypotheses_text}
-
-For EACH hypothesis, score the following criteria:
-- Novelty: How innovative/unique is this approach? (0=common, 1=breakthrough)
-- Impact: What level of positive change will this create? (0=minimal, 1=transformative)
-- Cost: What resources required? (0=very expensive, 1=very cheap)
-- Feasibility: How practical is implementation? (0=nearly impossible, 1=easily doable)
-- Risks: What could go wrong? (0=high risk/many issues, 1=low risk/few issues)
-
-Format your response EXACTLY as follows for EACH hypothesis:
-
-=== Hypothesis 1 ===
-Novelty: [score] - [one line explanation]
-Impact: [score] - [one line explanation]
-Cost: [score] - [one line explanation]
-Feasibility: [score] - [one line explanation]
-Risks: [score] - [one line explanation]
-
-=== Hypothesis 2 ===
-[Same format as above]
-
-[Continue for all hypotheses...]
-"""
     
-    def _parse_batch_evaluation_response(
-        self,
-        response: str,
-        hypotheses: List[str],
-        cost_per_hypothesis: float,
-        model: str,
-    ) -> List[HypothesisEvaluation]:
-        """Parse the batch LLM evaluation response into individual evaluations."""
-        evaluations = []
-        
-        # Split response by hypothesis sections
-        sections = re.split(r'===\s*Hypothesis\s*\d+\s*===', response)
-        sections = [s.strip() for s in sections if s.strip()]
-        
-        # If we can't parse sections properly, fall back to individual parsing
-        if len(sections) != len(hypotheses):
-            logger.warning(
-                "Batch parsing failed: expected %d sections, got %d. Falling back to individual parsing.",
-                len(hypotheses), len(sections)
-            )
-            # Try to parse as much as possible
-            for i, hypothesis in enumerate(hypotheses):
-                if i < len(sections):
-                    scores, explanations = self._parse_evaluation_response(sections[i])
-                else:
-                    scores = {
-                        "novelty": 0.5, "impact": 0.5, "cost": 0.5,
-                        "feasibility": 0.5, "risks": 0.5
-                    }
-                    explanations = dict.fromkeys(scores.keys(), "Failed to parse batch response")
-                
-                overall_score = calculate_hypothesis_score(scores)
-                evaluations.append(
-                    HypothesisEvaluation(
-                        content=hypothesis,
-                        scores=scores,
-                        overall_score=overall_score,
-                        explanations=explanations,
-                        metadata={
-                            "llm_cost": cost_per_hypothesis,
-                            "model": model,
-                            "batch_evaluation": True
-                        },
-                    )
-                )
-        else:
-            # Parse each section
-            for hypothesis, section in zip(hypotheses, sections):
-                scores, explanations = self._parse_evaluation_response(section)
-                overall_score = calculate_hypothesis_score(scores)
-                
-                evaluations.append(
-                    HypothesisEvaluation(
-                        content=hypothesis,
-                        scores=scores,
-                        overall_score=overall_score,
-                        explanations=explanations,
-                        metadata={
-                            "llm_cost": cost_per_hypothesis,
-                            "model": model,
-                            "batch_evaluation": True
-                        },
-                    )
-                )
-        
-        return evaluations


### PR DESCRIPTION
## Summary
Removed batch evaluation functionality from UnifiedEvaluator based on performance testing showing it was counterproductive.

## Performance Testing Results
- **Before (with batch)**: 25.79s for 10 evaluations with "Batch parsing failed" errors
- **After (without batch)**: 12.86s for 10 evaluations (50% faster, no errors)

## Why Remove Batch Evaluation?
1. **Token inflation**: Batch prompts were ~5x longer but only reduced API calls by 5x
2. **Net cost increase**: Larger prompts resulted in higher total token usage
3. **Cache incompatibility**: Hit rate dropped from 23.5% to 5.9% with batching
4. **Parsing issues**: Frequent "Batch parsing failed" messages

## Changes
- Removed `evaluate_batch()` and 3 helper methods (-195 lines)
- Updated `evaluate_multiple()` to use parallel individual evaluations
- Kept `batch_size` parameter for backward compatibility (ignored)

## Testing
- ✅ Tested unified evaluator with 10 hypotheses
- ✅ Tested evolution system
- ✅ Verified 50% performance improvement
- ✅ Confirmed no parsing errors