### PR TITLE
Fix timeout workaround script issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,6 @@ profile_*.py
 
 # Evolution checkpoints (runtime-generated temporary files)
 .evolution_checkpoints/
+
+# Output files from timeout workaround scripts
+outputs/

--- a/EVOLUTION_TIMEOUT_FIX.md
+++ b/EVOLUTION_TIMEOUT_FIX.md
@@ -3,7 +3,7 @@
 ## Problem Description
 
 When running `mad_spark_alt` with long-running commands (especially `--evolve`), commands are being killed after exactly 2 minutes (120 seconds) with the error message:
-```
+```text
 Command timed out after 2m 0.0s
 ```
 
@@ -47,7 +47,7 @@ The 2-minute timeout is imposed by the execution environment itself (terminal, s
 1. The script runs `mad_spark_alt` using `nohup` which detaches it from the terminal
 2. Output is saved to `outputs/mad_spark_alt_output_TIMESTAMP.txt`
 3. The process continues running even if the terminal is closed
-4. You can monitor progress with `tail -f outputs/mad_spark_alt_output_TIMESTAMP.txt`
+4. You can view the output with `cat outputs/mad_spark_alt_output_TIMESTAMP.txt`
 
 ### Output Location
 

--- a/EVOLUTION_TIMEOUT_FIX.md
+++ b/EVOLUTION_TIMEOUT_FIX.md
@@ -1,0 +1,90 @@
+# Evolution Timeout Fix Documentation
+
+## Problem Description
+
+When running `mad_spark_alt` with long-running commands (especially `--evolve`), commands are being killed after exactly 2 minutes (120 seconds) with the error message:
+```
+Command timed out after 2m 0.0s
+```
+
+This happens regardless of:
+- Running Python directly: `.venv/bin/mad_spark_alt ...` (still times out)
+- Using gtimeout with longer timeout: `gtimeout 600 uv run mad_spark_alt ...` (still times out)
+- The Python code's calculated timeout (correctly set to 600+ seconds for evolution)
+
+## Root Cause
+
+The 2-minute timeout is imposed by the execution environment itself (terminal, shell, or IDE), NOT by:
+- `uv run` command
+- Python's asyncio timeout
+- Shell timeout commands
+
+## Working Solution: Use the nohup Wrapper Script
+
+**Only the nohup approach successfully bypasses the timeout.**
+
+### Usage
+
+```bash
+./run_nohup.sh "Your prompt" [options]
+```
+
+### Examples
+
+```bash
+# Evolution with custom parameters
+./run_nohup.sh "Create a revolutionary game concept" --evolve --generations 3 --population 10
+
+# Simple evolution
+./run_nohup.sh "What is consciousness" --evolve
+
+# Regular analysis with high temperature
+./run_nohup.sh "Analyze this problem" --temperature 1.5
+```
+
+### How It Works
+
+1. The script runs `mad_spark_alt` using `nohup` which detaches it from the terminal
+2. Output is saved to `outputs/mad_spark_alt_output_TIMESTAMP.txt`
+3. The process continues running even if the terminal is closed
+4. You can monitor progress with `tail -f outputs/mad_spark_alt_output_TIMESTAMP.txt`
+
+### Output Location
+
+All output files are saved in the `outputs/` directory with timestamps:
+- Example: `outputs/mad_spark_alt_output_20250731_190000.txt`
+
+## Solutions That Don't Work
+
+The following approaches were tested but **still timeout at 2 minutes**:
+
+1. ❌ **Direct Python execution**: `.venv/bin/mad_spark_alt ...`
+2. ❌ **GNU timeout command**: `gtimeout 600 uv run mad_spark_alt ...`
+3. ❌ **Regular wrapper script**: `./run_evolution.sh ...` (may timeout in some environments)
+
+## Quick Reference
+
+### For Long-Running Tasks (Evolution, etc.)
+Always use:
+```bash
+./run_nohup.sh "Your prompt" --evolve --generations N --population N
+```
+
+### To Monitor Progress
+```bash
+# Find the latest output file
+ls -lt outputs/ | head -5
+
+# Monitor the output
+tail -f outputs/mad_spark_alt_output_TIMESTAMP.txt
+```
+
+### To Check if Still Running
+```bash
+# The script shows the PID when started
+ps -p [PID]
+```
+
+## Summary
+
+The only reliable way to run evolution or other long-running tasks is to use the `run_nohup.sh` script, which detaches the process from the terminal and avoids the 2-minute timeout imposed by the execution environment.

--- a/README.md
+++ b/README.md
@@ -126,12 +126,37 @@ uv run black src/ tests/ && uv run isort src/ tests/
 ```
 
 
+## Known Issues
+
+### 2-Minute Timeout in Some Environments
+
+When running long commands (especially with `--evolve`), you may encounter a timeout after exactly 2 minutes:
+```
+Command timed out after 2m 0.0s
+```
+
+This is caused by the execution environment (terminal/shell/IDE), not the application itself.
+
+**Solution**: Use the provided nohup wrapper script for long-running tasks:
+```bash
+# Instead of: uv run mad_spark_alt "prompt" --evolve
+# Use: ./run_nohup.sh "prompt" --evolve
+
+# Example
+./run_nohup.sh "Create a game concept" --evolve --generations 3 --population 10
+```
+
+Output will be saved to `outputs/mad_spark_alt_output_TIMESTAMP.txt`. 
+
+See [EVOLUTION_TIMEOUT_FIX.md](EVOLUTION_TIMEOUT_FIX.md) for detailed information.
+
 ## Documentation
 
 - [DEVELOPMENT.md](DEVELOPMENT.md): Architecture, API reference, contribution guide
 - [RESEARCH.md](RESEARCH.md): QADI methodology background
 - [SESSIONS.md](SESSIONS.md): Development history
 - [SEMANTIC_OPERATORS_IMPLEMENTATION.md](SEMANTIC_OPERATORS_IMPLEMENTATION.md): Semantic evolution operators guide
+- [EVOLUTION_TIMEOUT_FIX.md](EVOLUTION_TIMEOUT_FIX.md): Timeout issue workaround
 
 ## Session Handover
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ uv run black src/ tests/ && uv run isort src/ tests/
 ### 2-Minute Timeout in Some Environments
 
 When running long commands (especially with `--evolve`), you may encounter a timeout after exactly 2 minutes:
-```
+```text
 Command timed out after 2m 0.0s
 ```
 

--- a/run_evolution.sh
+++ b/run_evolution.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# Script to run mad_spark_alt with evolution without timeout issues
-# This script runs the command in the background to avoid shell timeouts
+set -euo pipefail
+# Script to run mad_spark_alt with evolution
+# This script runs the command in the foreground, replacing the shell process.
 
 # Check if at least one argument is provided
 if [ $# -eq 0 ]; then
@@ -11,7 +12,10 @@ fi
 
 # Ensure we're in the right directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd "$SCRIPT_DIR"
+cd "$SCRIPT_DIR" || {
+    echo "Error: Failed to change to script directory: $SCRIPT_DIR" >&2
+    exit 1
+}
 
 # Check if virtual environment exists
 if [ ! -d ".venv" ]; then

--- a/run_evolution.sh
+++ b/run_evolution.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Script to run mad_spark_alt with evolution without timeout issues
+# This script runs the command in the background to avoid shell timeouts
+
+# Check if at least one argument is provided
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 \"your prompt\" [--evolve] [--generations N] [--population N] [other options...]"
+    echo "Example: $0 \"Create a game concept\" --evolve --generations 3 --population 10"
+    exit 1
+fi
+
+# Ensure we're in the right directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
+
+# Check if virtual environment exists
+if [ ! -d ".venv" ]; then
+    echo "Error: Virtual environment not found at .venv"
+    echo "Please run 'uv sync' first"
+    exit 1
+fi
+
+# Check if mad_spark_alt is installed
+if [ ! -f ".venv/bin/mad_spark_alt" ]; then
+    echo "Error: mad_spark_alt not found in virtual environment"
+    echo "Please run 'uv pip install -e .' first"
+    exit 1
+fi
+
+echo "Starting Mad Spark Alt with evolution..."
+echo "Command: .venv/bin/mad_spark_alt $@"
+echo ""
+echo "⚠️  WARNING: This may timeout after 2 minutes in some environments."
+echo "   If you experience timeout issues, use ./run_nohup.sh instead."
+echo "----------------------------------------"
+
+# Run the command directly (not in background) to see output
+# The key is using the venv Python directly, which avoids uv run's timeout
+exec .venv/bin/mad_spark_alt "$@"

--- a/run_nohup.sh
+++ b/run_nohup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # Script to run mad_spark_alt commands using nohup to avoid terminal timeout issues
 # This detaches the process from the terminal completely, avoiding 2-minute timeout issues
 
@@ -17,7 +18,10 @@ fi
 
 # Ensure we're in the right directory
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-cd "$SCRIPT_DIR"
+cd "$SCRIPT_DIR" || {
+    echo "Error: Failed to change to script directory: $SCRIPT_DIR" >&2
+    exit 1
+}
 
 # Check if virtual environment exists
 if [ ! -d ".venv" ]; then
@@ -58,7 +62,7 @@ PID=$!
 
 echo "Process started with PID: $PID"
 echo ""
-echo "To monitor output:"
+echo "To view output:"
 echo "  cat $OUTPUT_FILE"
 echo ""
 echo "To check if still running:"

--- a/run_nohup.sh
+++ b/run_nohup.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Script to run mad_spark_alt commands using nohup to avoid terminal timeout issues
+# This detaches the process from the terminal completely, avoiding 2-minute timeout issues
+
+# Check if at least one argument is provided
+if [ $# -eq 0 ]; then
+    echo "Usage: $0 \"your prompt\" [options...]"
+    echo ""
+    echo "Examples:"
+    echo "  $0 \"Create a game concept\" --evolve --generations 3 --population 10"
+    echo "  $0 \"What is consciousness\" --evolve"
+    echo "  $0 \"Analyze this problem\" --temperature 1.5"
+    echo ""
+    echo "This script runs mad_spark_alt in the background to avoid 2-minute timeout issues."
+    exit 1
+fi
+
+# Ensure we're in the right directory
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "$SCRIPT_DIR"
+
+# Check if virtual environment exists
+if [ ! -d ".venv" ]; then
+    echo "Error: Virtual environment not found at .venv"
+    echo "Please run 'uv sync' first"
+    exit 1
+fi
+
+# Check if mad_spark_alt is installed
+if [ ! -f ".venv/bin/mad_spark_alt" ]; then
+    echo "Error: mad_spark_alt not found in virtual environment"
+    echo "Please run 'uv pip install -e .' first"
+    exit 1
+fi
+
+# Ensure outputs directory exists
+mkdir -p outputs
+
+# Create output filename with timestamp
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+OUTPUT_FILE="outputs/mad_spark_alt_output_${TIMESTAMP}.txt"
+
+echo "Starting Mad Spark Alt (detached to avoid timeout)..."
+echo "Command: .venv/bin/mad_spark_alt $@"
+echo "Output will be saved to: $OUTPUT_FILE"
+echo "----------------------------------------"
+
+# Run with nohup, redirecting output to file
+nohup .venv/bin/mad_spark_alt "$@" > "$OUTPUT_FILE" 2>&1 &
+PID=$!
+
+echo "Process started with PID: $PID"
+echo ""
+echo "To monitor progress:"
+echo "  tail -f $OUTPUT_FILE"
+echo ""
+echo "To check if still running:"
+echo "  ps -p $PID"
+echo ""
+echo "The process will continue even if you close this terminal."

--- a/run_nohup.sh
+++ b/run_nohup.sh
@@ -45,14 +45,21 @@ echo "Command: .venv/bin/mad_spark_alt $@"
 echo "Output will be saved to: $OUTPUT_FILE"
 echo "----------------------------------------"
 
-# Run with nohup, redirecting output to file
-nohup .venv/bin/mad_spark_alt "$@" > "$OUTPUT_FILE" 2>&1 &
+# Load environment variables if .env exists
+if [ -f ".env" ]; then
+    set -a  # automatically export all variables
+    source .env
+    set +a
+fi
+
+# Run with nohup, redirecting output to file with unbuffered output
+nohup env PYTHONUNBUFFERED=1 .venv/bin/mad_spark_alt "$@" > "$OUTPUT_FILE" 2>&1 &
 PID=$!
 
 echo "Process started with PID: $PID"
 echo ""
-echo "To monitor progress:"
-echo "  tail -f $OUTPUT_FILE"
+echo "To monitor output:"
+echo "  cat $OUTPUT_FILE"
 echo ""
 echo "To check if still running:"
 echo "  ps -p $PID"

--- a/tests/test_nohup_script.py
+++ b/tests/test_nohup_script.py
@@ -55,7 +55,7 @@ class TestNohupScript:
         
         assert result.returncode == 1, "Should exit with error code 1"
         assert "Usage:" in result.stdout, "Should show usage message"
-        assert "Example:" in result.stdout, "Should show example"
+        assert "Examples:" in result.stdout, "Should show examples"
     
     def test_script_checks_venv(self, script_dir, tmp_path):
         """Test script checks for virtual environment."""
@@ -138,7 +138,7 @@ class TestDocumentationUpdates:
             content = doc_path.read_text()
             
             # Should mention that direct execution doesn't work
-            assert "direct execution" in content.lower() or "still timed out" in content.lower(), \
+            assert "direct python execution" in content.lower() or "still times out" in content.lower(), \
                 "Should mention direct execution doesn't work"
             
             # Should emphasize nohup as the working solution

--- a/tests/test_nohup_script.py
+++ b/tests/test_nohup_script.py
@@ -1,0 +1,231 @@
+"""
+Tests for run_nohup.sh script functionality
+"""
+
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+import pytest
+
+
+class TestNohupScript:
+    """Test the nohup script functionality."""
+    
+    @pytest.fixture
+    def script_dir(self):
+        """Get the project root directory."""
+        return Path(__file__).parent.parent
+    
+    @pytest.fixture
+    def outputs_dir(self, script_dir):
+        """Ensure outputs directory exists."""
+        outputs = script_dir / "outputs"
+        outputs.mkdir(exist_ok=True)
+        return outputs
+    
+    def test_script_exists_after_rename(self, script_dir):
+        """Test that run_nohup.sh exists after renaming."""
+        script_path = script_dir / "run_nohup.sh"
+        assert script_path.exists(), "run_nohup.sh should exist"
+        assert os.access(script_path, os.X_OK), "run_nohup.sh should be executable"
+    
+    def test_outputs_directory_used(self, script_dir, outputs_dir):
+        """Test that script saves output to outputs directory."""
+        # This test will verify the script creates files in outputs/
+        # We'll check this by examining the script content
+        script_path = script_dir / "run_nohup.sh"
+        if script_path.exists():
+            with open(script_path, 'r') as f:
+                content = f.read()
+                assert 'outputs/' in content, "Script should use outputs directory"
+    
+    def test_script_handles_no_arguments(self, script_dir):
+        """Test script shows usage when no arguments provided."""
+        script_path = script_dir / "run_nohup.sh"
+        if not script_path.exists():
+            pytest.skip("Script not yet created")
+            
+        result = subprocess.run(
+            [str(script_path)],
+            capture_output=True,
+            text=True
+        )
+        
+        assert result.returncode == 1, "Should exit with error code 1"
+        assert "Usage:" in result.stdout, "Should show usage message"
+        assert "Example:" in result.stdout, "Should show example"
+    
+    def test_script_checks_venv(self, script_dir, tmp_path):
+        """Test script checks for virtual environment."""
+        # Create a temporary script location without .venv
+        temp_script = tmp_path / "run_nohup.sh"
+        
+        script_path = script_dir / "run_nohup.sh"
+        if not script_path.exists():
+            pytest.skip("Script not yet created")
+            
+        # Copy script to temp location
+        temp_script.write_text(script_path.read_text())
+        temp_script.chmod(0o755)
+        
+        # Run from temp directory (no .venv)
+        result = subprocess.run(
+            [str(temp_script), "test"],
+            cwd=tmp_path,
+            capture_output=True,
+            text=True
+        )
+        
+        assert result.returncode == 1, "Should exit with error"
+        assert "Virtual environment not found" in result.stdout, "Should warn about missing venv"
+    
+    def test_output_file_naming(self, script_dir, outputs_dir):
+        """Test that output files have timestamp in name."""
+        # Check script content for timestamp pattern
+        script_path = script_dir / "run_nohup.sh"
+        if script_path.exists():
+            with open(script_path, 'r') as f:
+                content = f.read()
+                assert 'date +%Y%m%d_%H%M%S' in content, "Should use timestamp in filename"
+                assert 'OUTPUT_FILE=' in content, "Should define OUTPUT_FILE variable"
+    
+    def test_script_shows_monitoring_instructions(self, script_dir):
+        """Test that script provides monitoring instructions."""
+        script_path = script_dir / "run_nohup.sh"
+        if not script_path.exists():
+            pytest.skip("Script not yet created")
+            
+        # We'll verify by checking script content
+        with open(script_path, 'r') as f:
+            content = f.read()
+            assert 'tail -f' in content, "Should show tail command"
+            assert 'ps -p' in content, "Should show ps command"
+
+
+class TestEvolutionScript:
+    """Test the direct evolution script."""
+    
+    @pytest.fixture
+    def script_dir(self):
+        """Get the project root directory."""
+        return Path(__file__).parent.parent
+    
+    def test_script_has_timeout_warning(self, script_dir):
+        """Test that run_evolution.sh warns about potential timeout."""
+        script_path = script_dir / "run_evolution.sh"
+        if script_path.exists():
+            with open(script_path, 'r') as f:
+                content = f.read()
+                # Should have warning about 2-minute timeout
+                assert 'timeout' in content.lower() or '2 minute' in content, \
+                    "Script should warn about potential timeout"
+
+
+class TestDocumentationUpdates:
+    """Test that documentation is properly updated."""
+    
+    @pytest.fixture
+    def project_root(self):
+        """Get project root directory."""
+        return Path(__file__).parent.parent
+    
+    def test_evolution_timeout_fix_updated(self, project_root):
+        """Test EVOLUTION_TIMEOUT_FIX.md has correct information."""
+        doc_path = project_root / "EVOLUTION_TIMEOUT_FIX.md"
+        if doc_path.exists():
+            content = doc_path.read_text()
+            
+            # Should mention that direct execution doesn't work
+            assert "direct execution" in content.lower() or "still timed out" in content.lower(), \
+                "Should mention direct execution doesn't work"
+            
+            # Should emphasize nohup as the working solution
+            assert "nohup" in content and ("only" in content.lower() or "working solution" in content.lower()), \
+                "Should emphasize nohup as the working solution"
+            
+            # Should reference run_nohup.sh (not run_evolution_nohup.sh)
+            assert "run_nohup.sh" in content, "Should reference renamed script"
+            assert "run_evolution_nohup.sh" not in content, "Should not reference old script name"
+    
+    def test_readme_has_known_issues(self, project_root):
+        """Test README.md has Known Issues section."""
+        readme_path = project_root / "README.md"
+        if readme_path.exists():
+            content = readme_path.read_text()
+            
+            # Should have Known Issues section
+            assert "known issues" in content.lower() or "timeout" in content.lower(), \
+                "README should mention timeout issue"
+            
+            # Should reference the nohup workaround
+            if "timeout" in content.lower():
+                assert "nohup" in content.lower() or "run_nohup" in content.lower(), \
+                    "README should reference nohup workaround"
+    
+    def test_gitignore_includes_outputs(self, project_root):
+        """Test .gitignore includes outputs directory."""
+        gitignore_path = project_root / ".gitignore"
+        if gitignore_path.exists():
+            content = gitignore_path.read_text()
+            # Should ignore outputs directory
+            assert "outputs/" in content or "outputs" in content, \
+                ".gitignore should include outputs directory"
+
+
+class TestOutputDirectory:
+    """Test outputs directory handling."""
+    
+    @pytest.fixture
+    def project_root(self):
+        """Get project root directory."""
+        return Path(__file__).parent.parent
+    
+    def test_outputs_directory_exists(self, project_root):
+        """Test that outputs directory exists."""
+        outputs_dir = project_root / "outputs"
+        assert outputs_dir.exists(), "outputs directory should exist"
+        assert outputs_dir.is_dir(), "outputs should be a directory"
+    
+    def test_old_output_file_moved(self, project_root):
+        """Test that old output file is moved to outputs directory."""
+        old_file = project_root / "evolution_output_20250731_185012.txt"
+        new_file = project_root / "outputs" / "evolution_output_20250731_185012.txt"
+        
+        # Either the old file doesn't exist (moved) or new file exists (moved to)
+        assert not old_file.exists() or new_file.exists(), \
+            "Old output file should be moved to outputs directory"
+
+
+@pytest.mark.integration
+class TestScriptIntegration:
+    """Integration tests for the scripts with real commands."""
+    
+    @pytest.fixture
+    def script_dir(self):
+        """Get the project root directory."""
+        return Path(__file__).parent.parent
+    
+    def test_nohup_script_creates_output_file(self, script_dir):
+        """Test that nohup script creates output file in outputs directory."""
+        script_path = script_dir / "run_nohup.sh"
+        outputs_dir = script_dir / "outputs"
+        
+        if not script_path.exists():
+            pytest.skip("Script not yet created")
+        
+        # Run a simple command that should complete quickly
+        result = subprocess.run(
+            [str(script_path), "test prompt", "--help"],
+            capture_output=True,
+            text=True
+        )
+        
+        # Should show output file location
+        assert "Output will be saved to: outputs/" in result.stdout, \
+            "Should indicate output location in outputs directory"
+        
+        # Should show process ID
+        assert "Process started with PID:" in result.stdout, \
+            "Should show process ID"

--- a/tests/test_nohup_script.py
+++ b/tests/test_nohup_script.py
@@ -100,7 +100,7 @@ class TestNohupScript:
         # We'll verify by checking script content
         with open(script_path, 'r') as f:
             content = f.read()
-            assert 'tail -f' in content, "Should show tail command"
+            assert 'cat' in content, "Should show cat command"
             assert 'ps -p' in content, "Should show ps command"
 
 


### PR DESCRIPTION
## Summary
- Fixed nohup script to properly handle environment variables and output buffering
- Updated monitoring instructions for better user experience
- Successfully tested with evolution commands running past 2-minute timeout

## Changes Made
1. **Script Improvements** (`run_nohup.sh`):
   - Added proper `.env` file loading to pass API keys to the subprocess
   - Enabled Python unbuffered output (`PYTHONUNBUFFERED=1`) for real-time monitoring
   - Changed monitoring instruction from `tail -f` to `cat` for better UX

2. **Test Updates** (`tests/test_nohup_script.py`):
   - Updated test assertions to match new monitoring command
   - All tests passing

3. **Documentation Updates** (from previous commits):
   - Renamed `run_evolution_nohup.sh` to `run_nohup.sh` for general use
   - Updated all documentation to reference only working solutions
   - Added "Known Issues" section to README
   - Created `outputs/` directory for output files

## Test Results
✅ Simple command test: Completed in 52.7s
✅ Evolution command test: Completed in 127.5s (successfully bypassed 2-minute timeout\!)

## Testing Instructions
1. Ensure you have a `.env` file with `GOOGLE_API_KEY` set
2. Run: `./run_nohup.sh "Your question here" --evolve --generations 3 --population 5`
3. Monitor output: `cat outputs/mad_spark_alt_output_TIMESTAMP.txt`
4. Verify process completes past 2 minutes

## Related Issues
Fixes the 2-minute timeout issue reported when running evolution commands in certain terminal environments.