### PR TITLE
docs: session handover and learnings from PR #101

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -413,7 +413,7 @@ print(f'Available methods: {list(registry._agents.keys())}')
 - **Critical Fix (PR #101)**: NEVER use category-based extraction (returns generic labels like "Technical/Technology Approach")
 - **Always Extract Content**: Use actual hypothesis content for titles, not classification categories
 - **Constants**: MAX_TITLE_LENGTH=80, MIN_MEANINGFUL_TITLE_LENGTH=10
-- **List Formatting**: Use pattern `r'(?<=[\s。.!?])\s*\((\d{1,2})\)\s*(?=[^\s\d])'` to avoid breaking years
+- **List Formatting**: Use pattern `r'(?<=[\s。.!?！？])\s*\((\d{1,2})\)\s*(?=[^\s\d])'` to avoid breaking years
 
 ### Terminal Timeout Workarounds (PR #69)
 - **Problem**: Some environments kill processes after exactly 2 minutes regardless of Python timeout settings

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -394,7 +394,7 @@ print(f'Available methods: {list(registry._agents.keys())}')
 - **Testing**: Comprehensive integration tests confirm structured output reliability
 - **Documentation**: See [STRUCTURED_OUTPUT.md](docs/STRUCTURED_OUTPUT.md) for details
 
-### Phase 2 Hypothesis Display Format (PR #89)
+### Phase 2 Hypothesis Display Format (PR #89, #101)
 - **User Preference**: Simple numbered list format without "**Approach X:**" labels
 - **Implementation**: Extract first sentence as title, display description on subsequent lines
 - **Format Example**:
@@ -410,6 +410,10 @@ print(f'Available methods: {list(registry._agents.keys())}')
 - **Cleaning Required**: Remove duplicate numbering and approach prefixes from LLM responses
 - **Title Extraction**: Use regex to find first sentence ending with standard punctuation (`.`, `?`, `!`)
 - **Fallback**: If no clear sentence boundary, display entire hypothesis with number
+- **Critical Fix (PR #101)**: NEVER use category-based extraction (returns generic labels like "Technical/Technology Approach")
+- **Always Extract Content**: Use actual hypothesis content for titles, not classification categories
+- **Constants**: MAX_TITLE_LENGTH=80, MIN_MEANINGFUL_TITLE_LENGTH=10
+- **List Formatting**: Use pattern `r'(?<=[\s。.!?])\s*\((\d{1,2})\)\s*(?=[^\s\d])'` to avoid breaking years
 
 ### Terminal Timeout Workarounds (PR #69)
 - **Problem**: Some environments kill processes after exactly 2 minutes regardless of Python timeout settings

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ See the `run_nohup.sh` script for our solution to terminal timeout issues.
   - **Category-Based Extraction Trap**: Never use keyword matching to classify content - it returns generic labels not actual content
   - **Actual Content Extraction**: Always extract the first meaningful sentence/phrase from the hypothesis itself
   - **Japanese/English Support**: Use language-specific punctuation patterns (.。!?！？) for sentence boundaries
-  - **List Item Detection**: Use precise regex `r'(?<=[\s。.!?])\s*\((\d{1,2})\)\s*(?=[^\s\d])'` to avoid treating years as list items
+  - **List Item Detection**: Use precise regex `r'(?<=[\s。.!?！？])\s*\((\d{1,2})\)\s*(?=[^\s\d])'` to avoid treating years as list items
   - **Systematic PR Review**: Even "simple" fixes benefit from 4-bot review process (found 4 distinct issues)
   - **Constants Over Magic Numbers**: Extract all numeric thresholds to named constants at module level
 - **Phase 1 Performance Optimization Success**: Batch semantic operators deliver dramatic improvements

--- a/README.md
+++ b/README.md
@@ -232,9 +232,14 @@ See the `run_nohup.sh` script for our solution to terminal timeout issues.
 
 ## Session Handover
 
-### Last Updated: August 04, 2025 02:57 PM JST
+### Last Updated: August 04, 2025 06:39 PM JST
 
 #### Recently Completed
+- ✅ **[PR #101] QADI Display Formatting Fix**: Improved hypothesis title extraction and analysis formatting (Aug 4, 2025)
+  - **Title Extraction**: Fixed evaluation scores showing generic category labels instead of actual hypothesis content
+  - **Analysis Section**: Added approach number display and fixed line break issues for numbered lists
+  - **Code Quality**: Addressed all feedback from 4 bot reviewers (claude[bot], coderabbitai[bot], cursor[bot], gemini-code-assist[bot])
+  - **Pattern Update**: Updated CLAUDE.md with critical fix - never use category-based extraction for titles
 - ✅ **[PR #97] Phase 1 Performance Optimizations**: Batch semantic operators for 60-70% performance improvement (Aug 4, 2025)
   - **Batch Processing**: BatchSemanticCrossoverOperator and BatchSemanticMutationOperator implemented
   - **Performance**: Heavy workloads now complete 60-70% faster through batch LLM operations
@@ -313,6 +318,13 @@ See the `run_nohup.sh` script for our solution to terminal timeout issues.
 - **Performance baseline established**: Evolution system now reliably completes without timeouts
 
 #### Session Learnings
+- **Hypothesis Title Extraction (PR #101)**: Critical lessons for user-facing text extraction
+  - **Category-Based Extraction Trap**: Never use keyword matching to classify content - it returns generic labels not actual content
+  - **Actual Content Extraction**: Always extract the first meaningful sentence/phrase from the hypothesis itself
+  - **Japanese/English Support**: Use language-specific punctuation patterns (.。!?！？) for sentence boundaries
+  - **List Item Detection**: Use precise regex `r'(?<=[\s。.!?])\s*\((\d{1,2})\)\s*(?=[^\s\d])'` to avoid treating years as list items
+  - **Systematic PR Review**: Even "simple" fixes benefit from 4-bot review process (found 4 distinct issues)
+  - **Constants Over Magic Numbers**: Extract all numeric thresholds to named constants at module level
 - **Phase 1 Performance Optimization Success**: Batch semantic operators deliver dramatic improvements
   - **Systematic Bug Fixing**: Layer-by-layer approach (logic → tests → feedback → types) prevents cascading issues
   - **ID Mapping Consistency**: Critical to establish 3-way consistency: prompts, parsing logic, test mocks


### PR DESCRIPTION
## Summary
Documentation update for session handover after PR #101 completion.

## Changes
- Updated Session Handover in README with date: August 04, 2025 06:39 PM JST
- Added PR #101 to completed work: critical QADI display formatting fixes
- Added new session learnings about hypothesis title extraction patterns
- Updated Phase 2 Hypothesis Display Format in CLAUDE.md with PR #101 critical fixes

## Learnings Captured
- Category-based extraction trap: returns generic labels not actual content
- Always extract first sentence/phrase from hypothesis itself
- Language-specific punctuation patterns for Japanese/English
- Precise regex to avoid breaking years in parentheses
- 4-bot review process catches subtle issues even in "simple" fixes

**Note**: Documentation-only PR, safe for quick merge.