### PR TITLE
refactor: reduce CLAUDE.md from 742 to 169 lines (77% reduction)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,11 @@ Mad Spark Alt is a Multi-Agent Idea Generation System powered by LLMs using the 
 - **User-Visible**: `logger.warning()` or higher for issues users need to know
 - **Internal Debug**: `logger.debug()` for fallbacks, parsing failures, internal state
 
+### Deprecation Best Practices
+- **Warn at module import**: Use `warnings.warn()` at module level
+- **Provide migration path**: Specify the new module/function to use
+- **Use `stacklevel=2`**: Pinpoint the caller location in warnings
+
 ### Evolution System
 - **API**: `GeneticAlgorithm()` with `EvolutionRequest` object, access `result.final_population`
 - **Mutation**: Creates new objects even at 0% rate; use 0.3+ for diversity
@@ -127,6 +132,11 @@ Mad Spark Alt is a Multi-Agent Idea Generation System powered by LLMs using the 
 - **Solution**: Write integration tests alongside unit tests from start
 - **Realistic Data**: Production-like responses in ALL mocks (copy actual API responses)
 - **Config Matrix**: Test ALL parameter combinations and boundaries
+
+### Claude Code Custom Commands
+- **$ARGUMENTS Support**: Custom commands accept arguments via `$ARGUMENTS`
+- **Example**: `/fix_pr_since_commit 1916eed` passes "1916eed" as `$ARGUMENTS`
+- **Implementation**: Use `${ARGUMENTS:-default_value}` for optional parameters
 
 ## Completed Features Reference
 


### PR DESCRIPTION
## Summary
- Reduce CLAUDE.md file size from 742 lines to 169 lines (77% reduction)
- Remove content duplicated from README.md, ARCHITECTURE.md, and DEVELOPMENT.md
- Consolidate 10 verbose PR completion sections into compact reference table
- Focus on critical patterns and quick references for Claude Code

## Changes
- **Removed duplicated sections** (-124 lines): Commands, Project Structure, Quick Verification (already in README.md/ARCHITECTURE.md)
- **Consolidated COMPLETED PR sections** (-353 lines → 20 lines): Converted verbose PR descriptions to compact table with key patterns
- **Condensed code examples** (-102 lines → 17 lines): Kept only 2 essential patterns (Resource Management, 3-Layer Fallback)
- **Removed redundant patterns** (~30 lines merged): AsyncMock pattern (2x), integration testing (4x), test metrics
- **Simplified implementation details** (~25 lines): Evolution config, ANSI patterns, semantic operator internals

## Test plan
- [x] Verify line count is under 500 (target: <500, actual: 169)
- [x] Ensure all critical warnings preserved (Never Use Template Agents)
- [x] Links to detailed documentation remain intact
- [x] No functionality changed (documentation only)